### PR TITLE
add 'X' to support unicode identifiers as the case-for-visibility rule

### DIFF
--- a/util.go
+++ b/util.go
@@ -20,6 +20,7 @@ import (
 	"regexp"
 	"sort"
 	"strings"
+	"unicode"
 )
 
 // Taken from https://github.com/golang/lint/blob/3390df4df2787994aea98de825b964ac7944b817/lint.go#L732-L769
@@ -269,7 +270,16 @@ func ToGoName(name string) string {
 		}
 		out = append(out, uw)
 	}
-	return strings.Join(out, "")
+
+	result := strings.Join(out, "")
+	ud := upper(result[:1])
+	ru := []rune(ud)
+	if unicode.IsUpper(ru[0]) {
+		result = ud + result[1:]
+	} else {
+		result = "X" + ud + result[1:]
+	}
+	return result
 }
 
 // ContainsStringsCI searches a slice of strings for a case-insensitive match

--- a/util_test.go
+++ b/util_test.go
@@ -37,6 +37,8 @@ func TestToGoName(t *testing.T) {
 		{"sampleText", "SampleText"},
 		{"sample 2 Text", "Sample2Text"},
 		{"findThingById", "FindThingByID"},
+		{"日本語sample 2 Text", "X日本語sample2Text"},
+		{"日本語findThingById", "X日本語findThingByID"},
 	}
 
 	for k := range commonInitialisms {


### PR DESCRIPTION
Sometimes 'Tag' is not written in ASCII. However "go-swagger" is using 'Tag' as beginning of function name. The function won't exported.
see also: https://golang.org/doc/faq#unicode_identifiers