### PR TITLE
Escape URI for local file load strategy

### DIFF
--- a/loading.go
+++ b/loading.go
@@ -19,6 +19,7 @@ import (
 	"io/ioutil"
 	"log"
 	"net/http"
+	"net/url"
 	"path/filepath"
 	"strings"
 	"time"
@@ -43,7 +44,10 @@ func LoadStrategy(path string, local, remote func(string) ([]byte, error)) func(
 	if strings.HasPrefix(path, "http") {
 		return remote
 	}
-	return func(pth string) ([]byte, error) { return local(filepath.FromSlash(pth)) }
+	return func(pth string) ([]byte, error) {
+		upth, _ := url.PathUnescape(pth)
+		return local(filepath.FromSlash(upth))
+	}
 }
 
 func loadHTTPBytes(timeout time.Duration) func(path string) ([]byte, error) {


### PR DESCRIPTION
This works around spec ref resolution moving all URI and puts it to work on windows.