### PR TITLE
Fix race condition with maps

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: go
 go:
 - 1.8
+- 1.9.x
+- 1.10.x
 install:
 - go get -u github.com/stretchr/testify
 - go get -u github.com/mailru/easyjson

--- a/post_go19.go
+++ b/post_go19.go
@@ -1,0 +1,53 @@
+// +build go1.9
+
+package swag
+
+import (
+	"sort"
+	"sync"
+)
+
+// indexOfInitialisms is a thread-safe implementation of the sorted index of initialisms.
+// Since go1.9, this may be implemented with sync.Map.
+type indexOfInitialisms struct {
+	sortMutex *sync.Mutex
+	index     *sync.Map
+}
+
+func newIndexOfInitialisms() *indexOfInitialisms {
+	return &indexOfInitialisms{
+		sortMutex: new(sync.Mutex),
+		index:     new(sync.Map),
+	}
+}
+
+func (m *indexOfInitialisms) load(initial map[string]bool) *indexOfInitialisms {
+	m.sortMutex.Lock()
+	defer m.sortMutex.Unlock()
+	for k, v := range initial {
+		m.index.Store(k, v)
+	}
+	return m
+}
+
+func (m *indexOfInitialisms) isInitialism(key string) bool {
+	_, ok := m.index.Load(key)
+	return ok
+}
+
+func (m *indexOfInitialisms) add(key string) *indexOfInitialisms {
+	m.index.Store(key, true)
+	return m
+}
+
+func (m *indexOfInitialisms) sorted() (result []string) {
+	m.sortMutex.Lock()
+	defer m.sortMutex.Unlock()
+	m.index.Range(func(key, value interface{}) bool {
+		k := key.(string)
+		result = append(result, k)
+		return true
+	})
+	sort.Sort(sort.Reverse(byLength(result)))
+	return
+}

--- a/pre_go19.go
+++ b/pre_go19.go
@@ -1,0 +1,55 @@
+// +build !go1.9
+
+package swag
+
+import (
+	"sort"
+	"sync"
+)
+
+// indexOfInitialisms is a thread-safe implementation of the sorted index of initialisms.
+// Before go1.9, this may be implemented with a mutex on the map.
+type indexOfInitialisms struct {
+	getMutex *sync.Mutex
+	index    map[string]bool
+}
+
+func newIndexOfInitialisms() *indexOfInitialisms {
+	return &indexOfInitialisms{
+		getMutex: new(sync.Mutex),
+		index:    make(map[string]bool, 50),
+	}
+}
+
+func (m *indexOfInitialisms) load(initial map[string]bool) *indexOfInitialisms {
+	m.getMutex.Lock()
+	defer m.getMutex.Unlock()
+	for k, v := range initial {
+		m.index[k] = v
+	}
+	return m
+}
+
+func (m *indexOfInitialisms) isInitialism(key string) bool {
+	m.getMutex.Lock()
+	defer m.getMutex.Unlock()
+	_, ok := m.index[key]
+	return ok
+}
+
+func (m *indexOfInitialisms) add(key string) *indexOfInitialisms {
+	m.getMutex.Lock()
+	defer m.getMutex.Unlock()
+	m.index[key] = true
+	return m
+}
+
+func (m *indexOfInitialisms) sorted() (result []string) {
+	m.getMutex.Lock()
+	defer m.getMutex.Unlock()
+	for k := range m.index {
+		result = append(result, k)
+	}
+	sort.Sort(sort.Reverse(byLength(result)))
+	return
+}

--- a/util.go
+++ b/util.go
@@ -18,63 +18,74 @@ import (
 	"math"
 	"reflect"
 	"regexp"
-	"sort"
 	"strings"
 	"sync"
 	"unicode"
 )
 
-// Taken from https://github.com/golang/lint/blob/3390df4df2787994aea98de825b964ac7944b817/lint.go#L732-L769
-var commonInitialisms = map[string]bool{
-	"ACL":   true,
-	"API":   true,
-	"ASCII": true,
-	"CPU":   true,
-	"CSS":   true,
-	"DNS":   true,
-	"EOF":   true,
-	"GUID":  true,
-	"HTML":  true,
-	"HTTPS": true,
-	"HTTP":  true,
-	"ID":    true,
-	"IP":    true,
-	"JSON":  true,
-	"LHS":   true,
-	"OAI":   true,
-	"QPS":   true,
-	"RAM":   true,
-	"RHS":   true,
-	"RPC":   true,
-	"SLA":   true,
-	"SMTP":  true,
-	"SQL":   true,
-	"SSH":   true,
-	"TCP":   true,
-	"TLS":   true,
-	"TTL":   true,
-	"UDP":   true,
-	"UI":    true,
-	"UID":   true,
-	"UUID":  true,
-	"URI":   true,
-	"URL":   true,
-	"UTF8":  true,
-	"VM":    true,
-	"XML":   true,
-	"XMPP":  true,
-	"XSRF":  true,
-	"XSS":   true,
-}
+// commonInitialisms are common acronyms that are kept as whole uppercased words.
+var commonInitialisms *indexOfInitialisms
+
+// initialisms is a slice of sorted initialisms
 var initialisms []string
 
 var once sync.Once
 
-func sortInitialisms() {
-	for k := range commonInitialisms {
-		initialisms = append(initialisms, k)
+var isInitialism func(string) bool
+
+func init() {
+	// Taken from https://github.com/golang/lint/blob/3390df4df2787994aea98de825b964ac7944b817/lint.go#L732-L769
+	var configuredInitialisms = map[string]bool{
+		"ACL":   true,
+		"API":   true,
+		"ASCII": true,
+		"CPU":   true,
+		"CSS":   true,
+		"DNS":   true,
+		"EOF":   true,
+		"GUID":  true,
+		"HTML":  true,
+		"HTTPS": true,
+		"HTTP":  true,
+		"ID":    true,
+		"IP":    true,
+		"JSON":  true,
+		"LHS":   true,
+		"OAI":   true,
+		"QPS":   true,
+		"RAM":   true,
+		"RHS":   true,
+		"RPC":   true,
+		"SLA":   true,
+		"SMTP":  true,
+		"SQL":   true,
+		"SSH":   true,
+		"TCP":   true,
+		"TLS":   true,
+		"TTL":   true,
+		"UDP":   true,
+		"UI":    true,
+		"UID":   true,
+		"UUID":  true,
+		"URI":   true,
+		"URL":   true,
+		"UTF8":  true,
+		"VM":    true,
+		"XML":   true,
+		"XMPP":  true,
+		"XSRF":  true,
+		"XSS":   true,
 	}
-	sort.Sort(sort.Reverse(byLength(initialisms)))
+
+	// a thread-safe index of initialisms
+	commonInitialisms = newIndexOfInitialisms().load(configuredInitialisms)
+
+	// a test function
+	isInitialism = commonInitialisms.isInitialism
+}
+
+func ensureSorted() {
+	initialisms = commonInitialisms.sorted()
 }
 
 // JoinByFormat joins a string array by a known format:
@@ -169,7 +180,7 @@ func split(str string) (words []string) {
 	str = rex1.ReplaceAllString(str, " $1")
 
 	// check if consecutive single char things make up an initialism
-	once.Do(sortInitialisms)
+	once.Do(ensureSorted)
 	for _, k := range initialisms {
 		str = strings.Replace(str, rex1.ReplaceAllString(k, " $1"), " "+k, -1)
 	}
@@ -230,7 +241,7 @@ func ToCommandName(name string) string {
 func ToHumanNameLower(name string) string {
 	var out []string
 	for _, w := range split(name) {
-		if !commonInitialisms[upper(w)] {
+		if !isInitialism(upper(w)) {
 			out = append(out, lower(w))
 		} else {
 			out = append(out, w)
@@ -244,7 +255,7 @@ func ToHumanNameTitle(name string) string {
 	var out []string
 	for _, w := range split(name) {
 		uw := upper(w)
-		if !commonInitialisms[uw] {
+		if !isInitialism(uw) {
 			out = append(out, upper(w[:1])+lower(w[1:]))
 		} else {
 			out = append(out, w)
@@ -269,7 +280,7 @@ func ToJSONName(name string) string {
 // ToVarName camelcases a name which can be underscored or pascal cased
 func ToVarName(name string) string {
 	res := ToGoName(name)
-	if _, ok := commonInitialisms[res]; ok {
+	if isInitialism(res) {
 		return lower(res)
 	}
 	if len(res) <= 1 {
@@ -284,7 +295,7 @@ func ToGoName(name string) string {
 	for _, w := range split(name) {
 		uw := upper(w)
 		mod := int(math.Min(float64(len(uw)), 2))
-		if !commonInitialisms[uw] && !commonInitialisms[uw[:len(uw)-mod]] {
+		if !isInitialism(uw) && !isInitialism(uw[:len(uw)-mod]) {
 			uw = upper(w[:1]) + lower(w[1:])
 		}
 		out = append(out, uw)
@@ -350,8 +361,11 @@ func IsZero(data interface{}) bool {
 // AddInitialisms add additional initialisms
 func AddInitialisms(words ...string) {
 	for _, word := range words {
-		commonInitialisms[upper(word)] = true
+		//commonInitialisms[upper(word)] = true
+		commonInitialisms.add(upper(word))
 	}
+	// sort again
+	initialisms = commonInitialisms.sorted()
 }
 
 // CommandLineOptionsGroup represents a group of user-defined command line options

--- a/util_test.go
+++ b/util_test.go
@@ -46,7 +46,7 @@ func TestToGoName(t *testing.T) {
 		{"findTHINGSbyID", "FindTHINGSbyID"},
 	}
 
-	for k := range commonInitialisms {
+	for _, k := range commonInitialisms.sorted() {
 		samples = append(samples,
 			translationSample{"sample " + lower(k) + " text", "Sample" + k + "Text"},
 			translationSample{"sample-" + lower(k) + "-text", "Sample" + k + "Text"},
@@ -137,7 +137,7 @@ func TestToFileName(t *testing.T) {
 		{"elbHTTPLoadBalancer", "elb_http_load_balancer"},
 		{"ELBHTTPLoadBalancer", "elb_http_load_balancer"},
 	}
-	for k := range commonInitialisms {
+	for _, k := range commonInitialisms.sorted() {
 		samples = append(samples,
 			translationSample{"Sample" + k + "Text", "sample_" + lower(k) + "_text"},
 		)
@@ -155,7 +155,7 @@ func TestToCommandName(t *testing.T) {
 		{"elbHTTPLoadBalancer", "elb-http-load-balancer"},
 	}
 
-	for k := range commonInitialisms {
+	for _, k := range commonInitialisms.sorted() {
 		samples = append(samples,
 			translationSample{"Sample" + k + "Text", "sample-" + lower(k) + "-text"},
 		)
@@ -173,7 +173,7 @@ func TestToHumanName(t *testing.T) {
 		{"elbHTTPLoadBalancer", "elb HTTP load balancer"},
 	}
 
-	for k := range commonInitialisms {
+	for _, k := range commonInitialisms.sorted() {
 		samples = append(samples,
 			translationSample{"Sample" + k + "Text", "sample " + k + " text"},
 		)
@@ -191,7 +191,7 @@ func TestToJSONName(t *testing.T) {
 		{"elbHTTPLoadBalancer", "elbHttpLoadBalancer"},
 	}
 
-	for k := range commonInitialisms {
+	for _, k := range commonInitialisms.sorted() {
 		samples = append(samples,
 			translationSample{"Sample" + k + "Text", "sample" + titleize(k) + "Text"},
 		)


### PR DESCRIPTION
There are two package level maps exposed to race conditions:
- commonInitialisms
- closers

This fix provides a sync.Map implementation for go19 (sync.Mutex pre-go19).
For closers (read-only map), an atomic.Value implementation is provided.

NOTE: I actually stumbled on the commonInitialism race when attempting to configure parallel testing in go-swagger. So with this, I may remove a clumsy mutex in this test source.