### PR TITLE
improve equality comparison for floats

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -22,8 +22,9 @@ import (
 
 // same as ECMA Number.MAX_SAFE_INTEGER and Number.MIN_SAFE_INTEGER
 const (
-	maxJSONFloat = float64(1<<53 - 1)  // 9007199254740991.0 	 	 2^53 - 1
-	minJSONFloat = -float64(1<<53 - 1) //-9007199254740991.0	-2^53 - 1
+	maxJSONFloat         = float64(1<<53 - 1)  // 9007199254740991.0 	 	 2^53 - 1
+	minJSONFloat         = -float64(1<<53 - 1) //-9007199254740991.0	-2^53 - 1
+	epsilon      float64 = 1e-9
 )
 
 // IsFloat64AJSONInteger allow for integers [-2^53, 2^53-1] inclusive
@@ -31,8 +32,22 @@ func IsFloat64AJSONInteger(f float64) bool {
 	if math.IsNaN(f) || math.IsInf(f, 0) || f < minJSONFloat || f > maxJSONFloat {
 		return false
 	}
+	fa := math.Abs(f)
+	g := float64(uint64(f))
+	ga := math.Abs(g)
 
-	return f == float64(int64(f)) || f == float64(uint64(f))
+	diff := math.Abs(f - g)
+
+	// more info: https://floating-point-gui.de/errors/comparison/#look-out-for-edge-cases
+	if f == g { // best case
+		return true
+	} else if f == float64(int64(f)) || f == float64(uint64(f)) { // optimistic case
+		return true
+	} else if f == 0 || g == 0 || diff < math.SmallestNonzeroFloat64 { // very close to 0 values
+		return diff < (epsilon * math.SmallestNonzeroFloat64)
+	}
+	// check the relative error
+	return diff/math.Min(fa+ga, math.MaxFloat64) < epsilon
 }
 
 var evaluatesAsTrue = map[string]struct{}{

--- a/convert_test.go
+++ b/convert_test.go
@@ -207,6 +207,7 @@ func TestIsFloat64AJSONInteger(t *testing.T) {
 	assert.True(t, IsFloat64AJSONInteger(1.0))
 	assert.True(t, IsFloat64AJSONInteger(maxJSONFloat))
 	assert.True(t, IsFloat64AJSONInteger(minJSONFloat))
+	assert.True(t, IsFloat64AJSONInteger(1/0.01*67.15000001))
 }
 
 func TestFormatBool(t *testing.T) {


### PR DESCRIPTION
fixes go-swagger/go-swagger#1618

Uses a more nuanced approach to comparing floating numbers in the `IsFloat64AJSONInteger` function