### PR TITLE
feat: improve split performance

### DIFF
--- a/util.go
+++ b/util.go
@@ -33,6 +33,12 @@ var once sync.Once
 
 var isInitialism func(string) bool
 
+var (
+	splitRex1     *regexp.Regexp
+	splitRex2     *regexp.Regexp
+	splitReplacer *strings.Replacer
+)
+
 func init() {
 	// Taken from https://github.com/golang/lint/blob/3390df4df2787994aea98de825b964ac7944b817/lint.go#L732-L769
 	var configuredInitialisms = map[string]bool{
@@ -164,12 +170,6 @@ func (s byLength) Swap(i, j int) {
 func (s byLength) Less(i, j int) bool {
 	return len(s[i]) < len(s[j])
 }
-
-var (
-	splitRex1     *regexp.Regexp
-	splitRex2     *regexp.Regexp
-	splitReplacer *strings.Replacer
-)
 
 // Prepares strings by splitting by caps, spaces, dashes, and underscore
 func split(str string) []string {

--- a/util_test.go
+++ b/util_test.go
@@ -67,6 +67,25 @@ func TestToGoName(t *testing.T) {
 	}
 }
 
+func BenchmarkToGoName(b *testing.B) {
+	samples := []string{
+		"sample text",
+		"sample-text",
+		"sample_text",
+		"sampleText",
+		"sample 2 Text",
+		"findThingById",
+		"日本語sample 2 Text",
+		"日本語findThingById",
+		"findTHINGSbyID",
+	}
+	for i := 0; i < b.N; i++ {
+		for _, s := range samples {
+			ToGoName(s)
+		}
+	}
+}
+
 func TestContainsStringsCI(t *testing.T) {
 	list := []string{"hello", "world", "and", "such"}
 


### PR DESCRIPTION
reduce construction of regexp and replacer.

```
name        old time/op  new time/op  delta
ToGoName-4  1.99ms ± 3%  0.44ms ± 2%  -77.98%  (p=0.000 n=10+10)
```
