### PR TITLE
Add lexicographically compare for equal by length initialisms

### DIFF
--- a/post_go19.go
+++ b/post_go19.go
@@ -62,6 +62,6 @@ func (m *indexOfInitialisms) sorted() (result []string) {
 		result = append(result, k)
 		return true
 	})
-	sort.Sort(sort.Reverse(byLength(result)))
+	sort.Sort(sort.Reverse(byInitialism(result)))
 	return
 }

--- a/pre_go19.go
+++ b/pre_go19.go
@@ -64,6 +64,6 @@ func (m *indexOfInitialisms) sorted() (result []string) {
 	for k := range m.index {
 		result = append(result, k)
 	}
-	sort.Sort(sort.Reverse(byLength(result)))
+	sort.Sort(sort.Reverse(byInitialism(result)))
 	return
 }

--- a/util.go
+++ b/util.go
@@ -159,16 +159,20 @@ func SplitByFormat(data, format string) []string {
 	return result
 }
 
-type byLength []string
+type byInitialism []string
 
-func (s byLength) Len() int {
+func (s byInitialism) Len() int {
 	return len(s)
 }
-func (s byLength) Swap(i, j int) {
+func (s byInitialism) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
-func (s byLength) Less(i, j int) bool {
-	return len(s[i]) < len(s[j])
+func (s byInitialism) Less(i, j int) bool {
+	if len(s[i]) != len(s[j]) {
+		return len(s[i]) < len(s[j])
+	}
+
+	return strings.Compare(s[i], s[j]) > 0
 }
 
 // Prepares strings by splitting by caps, spaces, dashes, and underscore

--- a/util_test.go
+++ b/util_test.go
@@ -33,6 +33,32 @@ func init() {
 	AddInitialisms("elb", "cap", "capwd", "wd")
 }
 
+func TestIndexOfInitialismsSorted(t *testing.T) {
+	configuredInitialisms := map[string]bool{
+		"ACL":   true,
+		"API":   true,
+		"ASCII": true,
+		"CPU":   true,
+		"CSS":   true,
+		"DNS":   true,
+		"VM":    true,
+		"XML":   true,
+		"XMPP":  true,
+		"XSRF":  true,
+		"XSS":   true,
+	}
+
+	goldenSample := newIndexOfInitialisms().load(configuredInitialisms).sorted()
+	for i := 0; i < 100; i++ {
+		sample := newIndexOfInitialisms().load(configuredInitialisms).sorted()
+		failMsg := "equal sorted initialisms should be always equal"
+
+		if !assert.Equal(t, goldenSample, sample, failMsg) {
+			t.FailNow()
+		}
+	}
+}
+
 func TestToGoName(t *testing.T) {
 	samples := []translationSample{
 		{"sample text", "SampleText"},


### PR DESCRIPTION
We have engage a situation with swagger, when the same string is time to time splitted differently. And as a result we have got undesirable diffs.

"SomethingTTLSeconds" can be matched as TTL or as t and TLS. This fix would not help in this situation, but at least fix some fluctuations.  