### PR TITLE
fix: invalid character '\x00' after top-level value

### DIFF
--- a/json.go
+++ b/json.go
@@ -68,15 +68,16 @@ func WriteJSON(data interface{}) ([]byte, error) {
 // ReadJSON reads json data, prefers finding an appropriate interface to short-circuit the unmarshaller
 // so it takes the fastes option available
 func ReadJSON(data []byte, value interface{}) error {
+	trimmedData := bytes.Trim(data, "\x00")
 	if d, ok := value.(ejUnmarshaler); ok {
-		jl := &jlexer.Lexer{Data: data}
+		jl := &jlexer.Lexer{Data: trimmedData}
 		d.UnmarshalEasyJSON(jl)
 		return jl.Error()
 	}
 	if d, ok := value.(json.Unmarshaler); ok {
-		return d.UnmarshalJSON(data)
+		return d.UnmarshalJSON(trimmedData)
 	}
-	return json.Unmarshal(data, value)
+	return json.Unmarshal(trimmedData, value)
 }
 
 // DynamicJSONToStruct converts an untyped json structure into a struct


### PR DESCRIPTION
Assuming I have test:
```
package models

import (
	"bytes"
	"encoding/hex"
	"testing"

	"github.com/.../models"
)

// Use https://codebeautify.org/hex-string-converter to convert testCase to json string

func TestUnmarshalingEventContent(t *testing.T) {
	testCases := []string{
		"7b2275736572223a7b22636c69656e744e616d65223a22736865706865726464656d6f222c22757365724e616d65223a2273686570686572642064656d6f206d616b657273227d7d",
		"7b2275736572223a7b22636c69656e744e616d65223a226578616d706c65636f7270222c22757365724e616d65223a2261646d696e227d7d00",
	}
	for i, testCase := range testCases {
		rawEventContent, err := hex.DecodeString(testCase)
		if err != nil {
			panic(err)
		}
		eventContent := models.EventContent{}
		err = eventContent.UnmarshalBinary(bytes.Trim(rawEventContent, "\x00"))
		if err != nil {
			t.Fatalf("An error '%s' occurred for test case #%d", err, i+1)
		}
	}
}
```
It only passes if I add `bytes.Trim(rawEventContent, "\x00")` otherwise I receive error `invalid character '\x00' after top-level value`.