### PR TITLE
fix camelize

### DIFF
--- a/util.go
+++ b/util.go
@@ -222,7 +222,7 @@ func lower(str string) string {
 
 // Camelize an uppercased word
 func Camelize(word string) (camelized string) {
-	for pos, ru := range word {
+	for pos, ru := range []rune(word) {
 		if pos > 0 {
 			camelized += string(unicode.ToLower(ru))
 		} else {
@@ -278,7 +278,7 @@ func ToHumanNameTitle(name string) string {
 	for _, w := range in {
 		uw := upper(w)
 		if !isInitialism(uw) {
-			out = append(out, upper(w[:1])+lower(w[1:]))
+			out = append(out, Camelize(w))
 		} else {
 			out = append(out, w)
 		}
@@ -296,7 +296,7 @@ func ToJSONName(name string) string {
 			out = append(out, lower(w))
 			continue
 		}
-		out = append(out, upper(w[:1])+lower(w[1:]))
+		out = append(out, Camelize(w))
 	}
 	return strings.Join(out, "")
 }
@@ -322,19 +322,17 @@ func ToGoName(name string) string {
 		uw := upper(w)
 		mod := int(math.Min(float64(len(uw)), 2))
 		if !isInitialism(uw) && !isInitialism(uw[:len(uw)-mod]) {
-			uw = upper(w[:1]) + lower(w[1:])
+			uw = Camelize(w)
 		}
 		out = append(out, uw)
 	}
 
 	result := strings.Join(out, "")
 	if len(result) > 0 {
-		ud := upper(result[:1])
-		ru := []rune(ud)
-		if unicode.IsUpper(ru[0]) {
-			result = ud + result[1:]
+		if unicode.IsUpper([]rune(result)[0]) {
+			result = result
 		} else {
-			result = "X" + ud + result[1:]
+			result = "X" + result
 		}
 	}
 	return result

--- a/util.go
+++ b/util.go
@@ -329,9 +329,7 @@ func ToGoName(name string) string {
 
 	result := strings.Join(out, "")
 	if len(result) > 0 {
-		if unicode.IsUpper([]rune(result)[0]) {
-			result = result
-		} else {
+		if !unicode.IsUpper([]rune(result)[0]) {
 			result = "X" + result
 		}
 	}


### PR DESCRIPTION
fix #26
Camelize works correctly with unicode in go1.12.

```
$ go version
go version go1.12 darwin/amd64
$ go test
PASS
ok      github.com/n-inja/swag  0.084s
```