### PR TITLE
Make default prefix in ToGoName configurable so go-swagger can plug in the pascalize func.

### DIFF
--- a/convert.go
+++ b/convert.go
@@ -39,11 +39,12 @@ func IsFloat64AJSONInteger(f float64) bool {
 	diff := math.Abs(f - g)
 
 	// more info: https://floating-point-gui.de/errors/comparison/#look-out-for-edge-cases
-	if f == g { // best case
+	switch {
+	case f == g: // best case
 		return true
-	} else if f == float64(int64(f)) || f == float64(uint64(f)) { // optimistic case
+	case f == float64(int64(f)) || f == float64(uint64(f)): // optimistic case
 		return true
-	} else if f == 0 || g == 0 || diff < math.SmallestNonzeroFloat64 { // very close to 0 values
+	case f == 0 || g == 0 || diff < math.SmallestNonzeroFloat64: // very close to 0 values
 		return diff < (epsilon * math.SmallestNonzeroFloat64)
 	}
 	// check the relative error

--- a/convert_test.go
+++ b/convert_test.go
@@ -208,6 +208,10 @@ func TestIsFloat64AJSONInteger(t *testing.T) {
 	assert.True(t, IsFloat64AJSONInteger(maxJSONFloat))
 	assert.True(t, IsFloat64AJSONInteger(minJSONFloat))
 	assert.True(t, IsFloat64AJSONInteger(1/0.01*67.15000001))
+	assert.False(t, IsFloat64AJSONInteger(math.SmallestNonzeroFloat64))
+	assert.False(t, IsFloat64AJSONInteger(math.SmallestNonzeroFloat64/2))
+	assert.True(t, IsFloat64AJSONInteger(math.SmallestNonzeroFloat64/3))
+	assert.True(t, IsFloat64AJSONInteger(math.SmallestNonzeroFloat64/4))
 }
 
 func TestFormatBool(t *testing.T) {

--- a/json.go
+++ b/json.go
@@ -99,7 +99,7 @@ func ConcatJSON(blobs ...[]byte) []byte {
 	last := len(blobs) - 1
 	for blobs[last] == nil || bytes.Equal(blobs[last], nullJSON) {
 		// strips trailing null objects
-		last = last - 1
+		last--
 		if last < 0 {
 			// there was nothing but "null"s or nil...
 			return nil

--- a/util.go
+++ b/util.go
@@ -16,6 +16,7 @@ package swag
 
 import (
 	"reflect"
+	"regexp"
 	"strings"
 	"unicode"
 )
@@ -27,6 +28,20 @@ var commonInitialisms *indexOfInitialisms
 var initialisms []string
 
 var isInitialism func(string) bool
+
+var (
+	splitRex1     *regexp.Regexp
+	splitRex2     *regexp.Regexp
+	splitReplacer *strings.Replacer
+)
+
+// GoNamePrefixFunc sets an optional rule to prefix go names
+// which do not start with a letter.
+//
+// e.g. to help converting "123" into "{prefix}123"
+//
+// The default is to prefix with "X"
+var GoNamePrefixFunc func(string) string
 
 func init() {
 	// Taken from https://github.com/golang/lint/blob/3390df4df2787994aea98de825b964ac7944b817/lint.go#L732-L769
@@ -291,7 +306,10 @@ func ToGoName(name string) string {
 		// Only prefix with X when the first character isn't an ascii letter
 		first := []rune(result)[0]
 		if !unicode.IsLetter(first) || (first > unicode.MaxASCII && !unicode.IsUpper(first)) {
-			result = "X" + result
+			if GoNamePrefixFunc == nil {
+				return "X" + result
+			}
+			result = GoNamePrefixFunc(name) + result
 		}
 		first = []rune(result)[0]
 		if unicode.IsLetter(first) && !unicode.IsUpper(first) {

--- a/util.go
+++ b/util.go
@@ -16,7 +16,6 @@ package swag
 
 import (
 	"reflect"
-	"regexp"
 	"strings"
 	"unicode"
 )
@@ -28,12 +27,6 @@ var commonInitialisms *indexOfInitialisms
 var initialisms []string
 
 var isInitialism func(string) bool
-
-var (
-	splitRex1     *regexp.Regexp
-	splitRex2     *regexp.Regexp
-	splitReplacer *strings.Replacer
-)
 
 // GoNamePrefixFunc sets an optional rule to prefix go names
 // which do not start with a letter.

--- a/util_test.go
+++ b/util_test.go
@@ -16,12 +16,13 @@ package swag
 
 import (
 	"fmt"
-	"github.com/stretchr/testify/require"
 	"log"
 	"strings"
 	"testing"
 	"time"
 	"unicode"
+
+	"github.com/stretchr/testify/require"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -403,6 +404,7 @@ func TestCamelize(t *testing.T) {
 		{"ELB.HTTPLoadBalancer", "Elb.httploadbalancer"},
 		{"elbHTTPLoadBalancer", "Elbhttploadbalancer"},
 		{"ELBHTTPLoadBalancer", "Elbhttploadbalancer"},
+		{"12ab", "12ab"},
 	}
 
 	for _, sample := range samples {
@@ -453,5 +455,38 @@ func TestToVarName(t *testing.T) {
 	for _, sample := range samples {
 		res := ToVarName(sample.str)
 		assert.Equalf(t, sample.out, res, "expected ToVarName(%q)=%q, got %q", sample.str, sample.out, res)
+	}
+}
+
+func TestToGoNameUnicode(t *testing.T) {
+	defer func() { GoNamePrefixFunc = nil }()
+	GoNamePrefixFunc = func(name string) string {
+		// this is the pascalize func from go-swagger codegen
+		arg := []rune(name)
+		if len(arg) == 0 || arg[0] > '9' {
+			return ""
+		}
+		if arg[0] == '+' {
+			return "Plus"
+		}
+		if arg[0] == '-' {
+			return "Minus"
+		}
+
+		return "Nr"
+	}
+
+	samples := []translationSample{
+		{"123_a", "Nr123a"},
+		{"!123_a", "Bang123a"},
+		{"+123_a", "Plus123a"},
+		{"abc", "Abc"},
+		{"éabc", "Éabc"},
+		{":éabc", "Éabc"},
+		// TODO: non unicode char
+	}
+
+	for _, sample := range samples {
+		assert.Equal(t, sample.out, ToGoName(sample.str))
 	}
 }


### PR DESCRIPTION
Make default prefix in ToGoName configurable so go-swagger can plug in the pascalize func.

In addition, fixed a few linting issues.

fixes go-swagger/go-swagger#1937