### PR TITLE
Add pointer and value conversions for the float32 type

### DIFF
--- a/convert_types.go
+++ b/convert_types.go
@@ -487,6 +487,7 @@ func Float32Value(v *float32) float32 {
 	if v != nil {
 		return *v
 	}
+
 	return 0
 }
 
@@ -494,9 +495,11 @@ func Float32Value(v *float32) float32 {
 // float32 pointers
 func Float32Slice(src []float32) []*float32 {
 	dst := make([]*float32, len(src))
+
 	for i := 0; i < len(src); i++ {
 		dst[i] = &(src[i])
 	}
+
 	return dst
 }
 
@@ -504,11 +507,13 @@ func Float32Slice(src []float32) []*float32 {
 // float32 values
 func Float32ValueSlice(src []*float32) []float32 {
 	dst := make([]float32, len(src))
+
 	for i := 0; i < len(src); i++ {
 		if src[i] != nil {
 			dst[i] = *(src[i])
 		}
 	}
+
 	return dst
 }
 
@@ -516,10 +521,12 @@ func Float32ValueSlice(src []*float32) []float32 {
 // map of float32 pointers
 func Float32Map(src map[string]float32) map[string]*float32 {
 	dst := make(map[string]*float32)
+
 	for k, val := range src {
 		v := val
 		dst[k] = &v
 	}
+
 	return dst
 }
 
@@ -527,11 +534,13 @@ func Float32Map(src map[string]float32) map[string]*float32 {
 // map of float32 values
 func Float32ValueMap(src map[string]*float32) map[string]float32 {
 	dst := make(map[string]float32)
+
 	for k, val := range src {
 		if val != nil {
 			dst[k] = *val
 		}
 	}
+
 	return dst
 }
 

--- a/convert_types.go
+++ b/convert_types.go
@@ -476,6 +476,65 @@ func Uint64ValueMap(src map[string]*uint64) map[string]uint64 {
 	return dst
 }
 
+// Float32 returns a pointer to of the float32 value passed in.
+func Float32(v float32) *float32 {
+	return &v
+}
+
+// Float32Value returns the value of the float32 pointer passed in or
+// 0 if the pointer is nil.
+func Float32Value(v *float32) float32 {
+	if v != nil {
+		return *v
+	}
+	return 0
+}
+
+// Float32Slice converts a slice of float32 values into a slice of
+// float32 pointers
+func Float32Slice(src []float32) []*float32 {
+	dst := make([]*float32, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+	return dst
+}
+
+// Float32ValueSlice converts a slice of float32 pointers into a slice of
+// float32 values
+func Float32ValueSlice(src []*float32) []float32 {
+	dst := make([]float32, len(src))
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+	return dst
+}
+
+// Float32Map converts a string map of float32 values into a string
+// map of float32 pointers
+func Float32Map(src map[string]float32) map[string]*float32 {
+	dst := make(map[string]*float32)
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+	return dst
+}
+
+// Float32ValueMap converts a string map of float32 pointers into a string
+// map of float32 values
+func Float32ValueMap(src map[string]*float32) map[string]float32 {
+	dst := make(map[string]float32)
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+	return dst
+}
+
 // Float64 returns a pointer to of the float64 value passed in.
 func Float64(v float64) *float64 {
 	return &v

--- a/convert_types_test.go
+++ b/convert_types_test.go
@@ -293,6 +293,7 @@ func TestFloat32Slice(t *testing.T) {
 		if in == nil {
 			continue
 		}
+
 		out := Float32Slice(in)
 		assertValues(t, in, out, true, idx)
 
@@ -423,6 +424,7 @@ func TestFloat32ValueSlice(t *testing.T) {
 		if in == nil {
 			continue
 		}
+
 		out := Float32ValueSlice(in)
 		assertValues(t, in, out, true, idx)
 
@@ -440,6 +442,7 @@ func TestFloat32Map(t *testing.T) {
 		if in == nil {
 			continue
 		}
+
 		out := Float32Map(in)
 		assertValues(t, in, out, true, idx)
 
@@ -747,6 +750,7 @@ func TestFloat32Value(t *testing.T) {
 		out2 := Float32Value(out)
 		assertValues(t, in, out2, false, idx)
 	}
+
 	assert.Zerof(t, Float32Value(nil), "expected conversion from nil to return zero value")
 }
 

--- a/convert_types_test.go
+++ b/convert_types_test.go
@@ -284,6 +284,23 @@ func TestInt64Map(t *testing.T) {
 	}
 }
 
+var testCasesFloat32Slice = [][]float32{
+	{1, 2, 3, 4},
+}
+
+func TestFloat32Slice(t *testing.T) {
+	for idx, in := range testCasesFloat32Slice {
+		if in == nil {
+			continue
+		}
+		out := Float32Slice(in)
+		assertValues(t, in, out, true, idx)
+
+		out2 := Float32ValueSlice(out)
+		assertValues(t, in, out2, false, idx)
+	}
+}
+
 var testCasesFloat64Slice = [][]float64{
 	{1, 2, 3, 4},
 }
@@ -395,6 +412,38 @@ func TestUint64Map(t *testing.T) {
 		assertValues(t, in, out, true, idx)
 
 		out2 := Uint64ValueMap(out)
+		assertValues(t, in, out2, false, idx)
+	}
+}
+
+var testCasesFloat32ValueSlice = [][]*float32{}
+
+func TestFloat32ValueSlice(t *testing.T) {
+	for idx, in := range testCasesFloat32ValueSlice {
+		if in == nil {
+			continue
+		}
+		out := Float32ValueSlice(in)
+		assertValues(t, in, out, true, idx)
+
+		out2 := Float32Slice(out)
+		assertValues(t, in, out2, false, idx)
+	}
+}
+
+var testCasesFloat32Map = []map[string]float32{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestFloat32Map(t *testing.T) {
+	for idx, in := range testCasesFloat32Map {
+		if in == nil {
+			continue
+		}
+		out := Float32Map(in)
+		assertValues(t, in, out, true, idx)
+
+		out2 := Float32ValueMap(out)
 		assertValues(t, in, out2, false, idx)
 	}
 }
@@ -686,6 +735,19 @@ func TestUint64Value(t *testing.T) {
 		assertValues(t, in, out2, false, idx)
 	}
 	assert.Zerof(t, Uint64Value(nil), "expected conversion from nil to return zero value")
+}
+
+var testCasesFloat32 = []float32{1, 2, 3, 0}
+
+func TestFloat32Value(t *testing.T) {
+	for idx, in := range testCasesFloat32 {
+		out := Float32(in)
+		assertValues(t, in, out, true, idx)
+
+		out2 := Float32Value(out)
+		assertValues(t, in, out2, false, idx)
+	}
+	assert.Zerof(t, Float32Value(nil), "expected conversion from nil to return zero value")
 }
 
 var testCasesFloat64 = []float64{1, 2, 3, 0}


### PR DESCRIPTION
This PR closes https://github.com/go-openapi/swag/issues/40 by adding pointer and value conversions for the `float32` type along with the associated tests.