### PR TITLE
Add pointer and value conversions for the uint16 type

### DIFF
--- a/convert_types.go
+++ b/convert_types.go
@@ -299,6 +299,73 @@ func Int64ValueMap(src map[string]*int64) map[string]int64 {
 	return dst
 }
 
+// Uint16 returns a pointer to of the uint16 value passed in.
+func Uint16(v uint16) *uint16 {
+	return &v
+}
+
+// Uint16Value returns the value of the uint16 pointer passed in or
+// 0 if the pointer is nil.
+func Uint16Value(v *uint16) uint16 {
+	if v != nil {
+		return *v
+	}
+
+	return 0
+}
+
+// Uint16Slice converts a slice of uint16 values into a slice of
+// uint16 pointers
+func Uint16Slice(src []uint16) []*uint16 {
+	dst := make([]*uint16, len(src))
+	for i := 0; i < len(src); i++ {
+		dst[i] = &(src[i])
+	}
+
+	return dst
+}
+
+// Uint16ValueSlice converts a slice of uint16 pointers into a slice of
+// uint16 values
+func Uint16ValueSlice(src []*uint16) []uint16 {
+	dst := make([]uint16, len(src))
+
+	for i := 0; i < len(src); i++ {
+		if src[i] != nil {
+			dst[i] = *(src[i])
+		}
+	}
+
+	return dst
+}
+
+// Uint16Map converts a string map of uint16 values into a string
+// map of uint16 pointers
+func Uint16Map(src map[string]uint16) map[string]*uint16 {
+	dst := make(map[string]*uint16)
+
+	for k, val := range src {
+		v := val
+		dst[k] = &v
+	}
+
+	return dst
+}
+
+// Uint16ValueMap converts a string map of uint16 pointers into a string
+// map of uint16 values
+func Uint16ValueMap(src map[string]*uint16) map[string]uint16 {
+	dst := make(map[string]uint16)
+
+	for k, val := range src {
+		if val != nil {
+			dst[k] = *val
+		}
+	}
+
+	return dst
+}
+
 // Uint returns a pointer to of the uint value passed in.
 func Uint(v uint) *uint {
 	return &v

--- a/convert_types_test.go
+++ b/convert_types_test.go
@@ -368,6 +368,58 @@ func TestUintMap(t *testing.T) {
 	}
 }
 
+var testCasesUint16Slice = [][]uint16{
+	{1, 2, 3, 4},
+}
+
+func TestUint16Slice(t *testing.T) {
+	for idx, in := range testCasesUint16Slice {
+		if in == nil {
+			continue
+		}
+
+		out := Uint16Slice(in)
+		assertValues(t, in, out, true, idx)
+
+		out2 := Uint16ValueSlice(out)
+		assertValues(t, in, out2, false, idx)
+	}
+}
+
+var testCasesUint16ValueSlice = [][]*uint16{}
+
+func TestUint16ValueSlice(t *testing.T) {
+	for idx, in := range testCasesUint16ValueSlice {
+		if in == nil {
+			continue
+		}
+
+		out := Uint16ValueSlice(in)
+		assertValues(t, in, out, true, idx)
+
+		out2 := Uint16Slice(out)
+		assertValues(t, in, out2, false, idx)
+	}
+}
+
+var testCasesUint16Map = []map[string]uint16{
+	{"a": 3, "b": 2, "c": 1},
+}
+
+func TestUint16Map(t *testing.T) {
+	for idx, in := range testCasesUint16Map {
+		if in == nil {
+			continue
+		}
+
+		out := Uint16Map(in)
+		assertValues(t, in, out, true, idx)
+
+		out2 := Uint16ValueMap(out)
+		assertValues(t, in, out2, false, idx)
+	}
+}
+
 var testCasesUint64Slice = [][]uint64{
 	{1, 2, 3, 4},
 }


### PR DESCRIPTION
This PR closes https://github.com/go-openapi/swag/issues/42 by adding pointer and value conversions for the uint16 type along with the associated tests.