### PR TITLE
Enable use of Basic Auth and custom HTTP Headers

### DIFF
--- a/loading.go
+++ b/loading.go
@@ -27,6 +27,15 @@ import (
 // LoadHTTPTimeout the default timeout for load requests
 var LoadHTTPTimeout = 30 * time.Second
 
+// LoadHTTPBasicAuthUsername the username to use when load requests require basic auth
+var LoadHTTPBasicAuthUsername = ""
+
+// LoadHTTPBasicAuthPassword the password to use when load requests require basic auth
+var LoadHTTPBasicAuthPassword = ""
+
+// LoadHTTPCustomHeaders an optional collection of custom HTTP headers for load requests
+var LoadHTTPCustomHeaders = map[string]string{}
+
 // LoadFromFileOrHTTP loads the bytes from a file or a remote http server based on the path passed in
 func LoadFromFileOrHTTP(path string) ([]byte, error) {
 	return LoadStrategy(path, ioutil.ReadFile, loadHTTPBytes(LoadHTTPTimeout))(path)
@@ -59,6 +68,15 @@ func loadHTTPBytes(timeout time.Duration) func(path string) ([]byte, error) {
 		if err != nil {
 			return nil, err
 		}
+
+		if LoadHTTPBasicAuthUsername != "" && LoadHTTPBasicAuthPassword != "" {
+			req.SetBasicAuth(LoadHTTPBasicAuthUsername, LoadHTTPBasicAuthPassword)
+		}
+
+		for key, val := range LoadHTTPCustomHeaders {
+			req.Header.Set(key, val)
+		}
+
 		resp, err := client.Do(req)
 		defer func() {
 			if resp != nil {


### PR DESCRIPTION
As discussed in #44, sometimes the swagger specs we want to load are behind authentication requiring basic auth or some other requirements around custom HTTP headers.

This commit adds three new package-level variables, similar in scope to the existing `swag.LoadHTTPTimeout` variable, which can be overridden in client code (e.g. go-swagger) to customize the behaviour of the swagger spec load client:

- `swag.LoadHTTPBasicAuthUsername` and `swag.LoadHTTPBasicAuthPassword`

    When both are non-empty the `http.Client` request's `SetBasicAuth(..)` method is invoked to decorate the request with these credentials as a Basic Auth value in the Authorization header.

- `swag.LoadHTTPCustomHeaders`

    Before sending the load request this `map[string]string` of `[key]value` pairs is applied to the   `request.Headers` collection.

    This can be used to configure additional custom header requirements (e.g. your
  swagger.json may only be available when clients include a custom header like:

    ````
    X-Myapp-Header: AppName
    ````