### PR TITLE
Copy runtime.File as swag.File

### DIFF
--- a/file.go
+++ b/file.go
@@ -1,0 +1,33 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import "mime/multipart"
+
+// File represents an uploaded file.
+type File struct {
+	Data   multipart.File
+	Header *multipart.FileHeader
+}
+
+// Read bytes from the file
+func (f *File) Read(p []byte) (n int, err error) {
+	return f.Data.Read(p)
+}
+
+// Close the file
+func (f *File) Close() error {
+	return f.Data.Close()
+}

--- a/file_test.go
+++ b/file_test.go
@@ -1,0 +1,20 @@
+package swag
+
+import (
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestFileImplementsIOReader(t *testing.T) {
+	var file interface{} = &File{}
+	expected := "that File implements io.Reader"
+	assert.Implements(t, new(io.Reader), file, expected)
+}
+
+func TestFileImplementsIOReadCloser(t *testing.T) {
+	var file interface{} = &File{}
+	expected := "that File implements io.ReadCloser"
+	assert.Implements(t, new(io.ReadCloser), file, expected)
+}


### PR DESCRIPTION
The File type is defined in go-openapi/runtime and used from
go-openapi/validate. However the runtime package uses the validate
package which makes a circular dependency between them.

https://github.com/go-openapi/validate/issues/143

Signed-off-by: Kazuyoshi Kato <katokazu@amazon.com>