### PR TITLE
check for nil pointers before calling IsZero.

### DIFF
--- a/util.go
+++ b/util.go
@@ -344,7 +344,7 @@ func IsZero(data interface{}) bool {
 	v := reflect.ValueOf(data)
 	// check for nil data
 	switch v.Kind() {
-	case reflect.Interface, reflect.Ptr:
+	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
 		if v.IsNil() {
 			return true
 		}
@@ -367,14 +367,13 @@ func IsZero(data interface{}) bool {
 		return v.Uint() == 0
 	case reflect.Float32, reflect.Float64:
 		return v.Float() == 0
-	case reflect.Interface, reflect.Map, reflect.Ptr, reflect.Slice:
-		return v.IsNil()
 	case reflect.Struct, reflect.Array:
 		return reflect.DeepEqual(data, reflect.Zero(v.Type()).Interface())
 	case reflect.Invalid:
 		return true
+	default:
+		return false
 	}
-	return false
 }
 
 // AddInitialisms add additional initialisms

--- a/util.go
+++ b/util.go
@@ -341,12 +341,21 @@ type zeroable interface {
 // IsZero returns true when the value passed into the function is a zero value.
 // This allows for safer checking of interface values.
 func IsZero(data interface{}) bool {
+	v := reflect.ValueOf(data)
+	// check for nil data
+	switch v.Kind() {
+	case reflect.Interface, reflect.Ptr:
+		if v.IsNil() {
+			return true
+		}
+	}
+
 	// check for things that have an IsZero method instead
 	if vv, ok := data.(zeroable); ok {
 		return vv.IsZero()
 	}
+
 	// continue with slightly more complex reflection
-	v := reflect.ValueOf(data)
 	switch v.Kind() {
 	case reflect.String:
 		return v.Len() == 0

--- a/util_test.go
+++ b/util_test.go
@@ -490,3 +490,21 @@ func TestToGoNameUnicode(t *testing.T) {
 		assert.Equal(t, sample.out, ToGoName(sample.str))
 	}
 }
+
+type dummyZeroable struct {
+	zero bool
+}
+
+func (d dummyZeroable) IsZero() bool {
+	return d.zero
+}
+func TestZeroableNilIsZero(t *testing.T) {
+	var d *dummyZeroable
+
+	assert.True(t, IsZero(d))
+}
+
+func TestZeroableInterfaceIsRespected(t *testing.T) {
+	assert.False(t, IsZero(dummyZeroable{false}))
+	assert.True(t, IsZero(dummyZeroable{true}))
+}

--- a/util_test.go
+++ b/util_test.go
@@ -309,6 +309,14 @@ type ZeroesWithTime struct {
 	Time time.Time
 }
 
+type dummyZeroable struct {
+	zero bool
+}
+
+func (d dummyZeroable) IsZero() bool {
+	return d.zero
+}
+
 func TestIsZero(t *testing.T) {
 	var strs [5]string
 	var strss []string
@@ -384,6 +392,9 @@ func TestIsZero(t *testing.T) {
 		{[...]string{"hello"}, false},
 		{[]string(nil), true},
 		{[]string{"a"}, false},
+		{&dummyZeroable{true}, true},
+		{&dummyZeroable{false}, false},
+		{(*dummyZeroable)(nil), true},
 	}
 
 	for _, it := range data {
@@ -489,22 +500,4 @@ func TestToGoNameUnicode(t *testing.T) {
 	for _, sample := range samples {
 		assert.Equal(t, sample.out, ToGoName(sample.str))
 	}
-}
-
-type dummyZeroable struct {
-	zero bool
-}
-
-func (d dummyZeroable) IsZero() bool {
-	return d.zero
-}
-func TestZeroableNilIsZero(t *testing.T) {
-	var d *dummyZeroable
-
-	assert.True(t, IsZero(d))
-}
-
-func TestZeroableInterfaceIsRespected(t *testing.T) {
-	assert.False(t, IsZero(dummyZeroable{false}))
-	assert.True(t, IsZero(dummyZeroable{true}))
 }


### PR DESCRIPTION
This avoids panics when a nil pointer to a type that implements zeroable interface is passed to IsZero

fixes https://github.com/go-openapi/swag/issues/66