### PR TITLE
ci: remove paths-ignores

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -6,12 +6,8 @@ on:
       - v*
     branches:
       - master
-    paths-ignore:
-      - '**.md'
 
   pull_request:
-    paths-ignore:
-      - '**.md'
 
 jobs:
   lint:


### PR DESCRIPTION
Using paths-ignore as a short-circuit for doc-only PRs does not work: branch protection rules cannot be passed.