### PR TITLE
feat(loading): HTTP or file loader configurable with LoadingOptions

### DIFF
--- a/loading.go
+++ b/loading.go
@@ -157,16 +157,12 @@ func loadHTTPBytes(opts ...LoadingOption) func(path string) ([]byte, error) {
 
 	return func(path string) ([]byte, error) {
 		client := o.client
-		var (
-			timeoutCtx context.Context
-			cancel     func()
-		)
+		timeoutCtx := context.Background()
+		var cancel func()
 
 		if o.httpTimeout > 0 {
-			timeoutCtx, cancel = context.WithTimeout(context.Background(), o.httpTimeout)
+			timeoutCtx, cancel = context.WithTimeout(timeoutCtx, o.httpTimeout)
 			defer cancel()
-		} else {
-			timeoutCtx = context.Background()
 		}
 
 		req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, path, nil)

--- a/loading.go
+++ b/loading.go
@@ -15,12 +15,12 @@
 package swag
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 	"path/filepath"
 	"runtime"
@@ -29,26 +29,39 @@ import (
 )
 
 // LoadHTTPTimeout the default timeout for load requests
+//
+// Deprecated: use [LoadingWithTimeout] option instead.
 var LoadHTTPTimeout = 30 * time.Second
 
 // LoadHTTPBasicAuthUsername the username to use when load requests require basic auth
+//
+// Deprecated: use [LoadingWithBasicAuth] option instead.
 var LoadHTTPBasicAuthUsername = ""
 
 // LoadHTTPBasicAuthPassword the password to use when load requests require basic auth
+//
+// Deprecated: use [LoadingWithBasicAuth] option instead.
 var LoadHTTPBasicAuthPassword = ""
 
 // LoadHTTPCustomHeaders an optional collection of custom HTTP headers for load requests
+//
+// Deprecated: use [LoadingWithCustomHeaders] option instead.
 var LoadHTTPCustomHeaders = map[string]string{}
 
 // LoadFromFileOrHTTP loads the bytes from a file or a remote http server based on the path passed in
-func LoadFromFileOrHTTP(pth string) ([]byte, error) {
-	return LoadStrategy(pth, os.ReadFile, loadHTTPBytes(LoadHTTPTimeout))(pth)
+func LoadFromFileOrHTTP(pth string, opts ...LoadingOption) ([]byte, error) {
+	o := loadingOptionsWithDefaults(opts)
+	return LoadStrategy(pth, o.ReadFileFunc(), loadHTTPBytes(opts...), opts...)(pth)
 }
 
 // LoadFromFileOrHTTPWithTimeout loads the bytes from a file or a remote http server based on the path passed in
-// timeout arg allows for per request overriding of the request timeout
-func LoadFromFileOrHTTPWithTimeout(pth string, timeout time.Duration) ([]byte, error) {
-	return LoadStrategy(pth, os.ReadFile, loadHTTPBytes(timeout))(pth)
+// timeout arg allows for per request overriding of the request timeout.
+//
+// Deprecated: use LoadFromFileOrHTTP with the [LoadingWithTimeout] option instead.
+func LoadFromFileOrHTTPWithTimeout(pth string, timeout time.Duration, opts ...LoadingOption) ([]byte, error) {
+	opts = append(opts, LoadingWithTimeout(timeout))
+
+	return LoadFromFileOrHTTP(pth, opts...)
 }
 
 // LoadStrategy returns a loader function for a given path or URI.
@@ -81,7 +94,7 @@ func LoadFromFileOrHTTPWithTimeout(pth string, timeout time.Duration) ([]byte, e
 // - `file://host/folder/file` becomes an UNC path like `\\host\folder\file` (no port specification is supported)
 // - `file:///c:/folder/file` becomes `C:\folder\file`
 // - `file://c:/folder/file` is tolerated (without leading `/`) and becomes `c:\folder\file`
-func LoadStrategy(pth string, local, remote func(string) ([]byte, error)) func(string) ([]byte, error) {
+func LoadStrategy(pth string, local, remote func(string) ([]byte, error), _ ...LoadingOption) func(string) ([]byte, error) {
 	if strings.HasPrefix(pth, "http") {
 		return remote
 	}
@@ -139,19 +152,33 @@ func LoadStrategy(pth string, local, remote func(string) ([]byte, error)) func(s
 	}
 }
 
-func loadHTTPBytes(timeout time.Duration) func(path string) ([]byte, error) {
+func loadHTTPBytes(opts ...LoadingOption) func(path string) ([]byte, error) {
+	o := loadingOptionsWithDefaults(opts)
+
 	return func(path string) ([]byte, error) {
-		client := &http.Client{Timeout: timeout}
-		req, err := http.NewRequest(http.MethodGet, path, nil) //nolint:noctx
+		client := o.client
+		var (
+			timeoutCtx context.Context
+			cancel     func()
+		)
+
+		if o.httpTimeout > 0 {
+			timeoutCtx, cancel = context.WithTimeout(context.Background(), o.httpTimeout)
+			defer cancel()
+		} else {
+			timeoutCtx = context.Background()
+		}
+
+		req, err := http.NewRequestWithContext(timeoutCtx, http.MethodGet, path, nil)
 		if err != nil {
 			return nil, err
 		}
 
-		if LoadHTTPBasicAuthUsername != "" && LoadHTTPBasicAuthPassword != "" {
-			req.SetBasicAuth(LoadHTTPBasicAuthUsername, LoadHTTPBasicAuthPassword)
+		if o.basicAuthUsername != "" && o.basicAuthPassword != "" {
+			req.SetBasicAuth(o.basicAuthUsername, o.basicAuthPassword)
 		}
 
-		for key, val := range LoadHTTPCustomHeaders {
+		for key, val := range o.customHeaders {
 			req.Header.Set(key, val)
 		}
 

--- a/loading_options.go
+++ b/loading_options.go
@@ -1,0 +1,119 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import (
+	"io/fs"
+	"net/http"
+	"os"
+	"time"
+)
+
+type (
+	// LoadingOption provides options for loading a file over HTTP or from a file.
+	LoadingOption func(*loadingOptions)
+
+	httpOptions struct {
+		httpTimeout       time.Duration
+		basicAuthUsername string
+		basicAuthPassword string
+		customHeaders     map[string]string
+		client            *http.Client
+	}
+
+	fileOptions struct {
+		fs fs.ReadFileFS
+	}
+
+	loadingOptions struct {
+		httpOptions
+		fileOptions
+	}
+)
+
+func (fo fileOptions) ReadFileFunc() func(string) ([]byte, error) {
+	if fo.fs == nil {
+		return os.ReadFile
+	}
+
+	return fo.fs.ReadFile
+}
+
+// LoadingWithTimeout sets a timeout for the remote file loader.
+func LoadingWithTimeout(timeout time.Duration) LoadingOption {
+	return func(o *loadingOptions) {
+		o.httpTimeout = timeout
+	}
+}
+
+// LoadingWithBasicAuth sets a basic authentication scheme for the remote file loader.
+func LoadingWithBasicAuth(username, password string) LoadingOption {
+	return func(o *loadingOptions) {
+		o.basicAuthUsername = username
+		o.basicAuthPassword = password
+	}
+}
+
+// LoadingWithCustomHeaders sets custom headers for the remote file loader.
+func LoadingWithCustomHeaders(headers map[string]string) LoadingOption {
+	return func(o *loadingOptions) {
+		if o.customHeaders == nil {
+			o.customHeaders = make(map[string]string, len(headers))
+		}
+
+		for header, value := range headers {
+			o.customHeaders[header] = value
+		}
+	}
+}
+
+// LoadingWithHTTClient overrides the default HTTP client used to fetch a remote file.
+//
+// By default, [http.DefaultClient] is used.
+func LoadingWithHTTPClient(client *http.Client) LoadingOption {
+	return func(o *loadingOptions) {
+		o.client = client
+	}
+}
+
+// LoadingWithFS sets a file system for the local file loader.
+//
+// By default, the file system is the one provided by the os package.
+//
+// For example, this may be set to consume from an embedded file system, or a rooted FS.
+func LoadingWithFS(fs fs.ReadFileFS) LoadingOption {
+	return func(o *loadingOptions) {
+		o.fs = fs
+	}
+}
+
+func loadingOptionsWithDefaults(opts []LoadingOption) loadingOptions {
+	o := loadingOptions{
+		// package level defaults
+		httpOptions: httpOptions{
+			httpTimeout:       LoadHTTPTimeout,
+			customHeaders:     LoadHTTPCustomHeaders,
+			basicAuthUsername: LoadHTTPBasicAuthUsername,
+			basicAuthPassword: LoadHTTPBasicAuthPassword,
+			client:            http.DefaultClient,
+		},
+	}
+
+	for _, apply := range opts {
+		apply(&o)
+	}
+
+	return o
+}


### PR DESCRIPTION
This PR deprecates package-level configurations for the HTTP or file loader utility, by introducing a set of options.

It is a non-breaking change, as package-level variables are still consumed as the default options.

Besides existing configurations (timeout, basic auth, custom headers), we add the possibility to inject a custom http client.

For the local file loader, we add the possibility to inject a FS, for example to be used with a dir-rooted FS or an embedded FS.

* contributes https://github.com/go-openapi/loads/issues/72
* refactored and augmented loading tests, with t.Run for improved test readability