### PR TITLE
Mangling: added support for pluralized initialisms

### DIFF
--- a/split_test.go
+++ b/split_test.go
@@ -3,8 +3,163 @@ package swag
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+func TestSplitPluralized(t *testing.T) {
+	s := newSplitter(withPostSplitInitialismCheck)
+
+	t.Run("should recognize pluralized initialisms", func(t *testing.T) {
+		t.Run("with trailing initialism", func(t *testing.T) {
+			const plurals = "pluralized initialism IDs"
+			lexems := s.split(plurals)
+			poolOfLexems.RedeemLexems(lexems)
+
+			require.NotNil(t, lexems)
+			require.Len(t, *lexems, 3)
+
+			assert.Equal(t, "PluralizedInitialismIDs", ToGoName(plurals))
+			assert.Equal(t, "pluralized_initialism_ids", ToFileName(plurals))
+		})
+
+		t.Run("with initialism trailed by capital", func(t *testing.T) {
+			const plurals = "pluralized initialism IDsX"
+			lexems := s.split(plurals)
+			poolOfLexems.RedeemLexems(lexems)
+
+			require.NotNil(t, lexems)
+			require.Len(t, *lexems, 4)
+
+			assert.Equal(t, "PluralizedInitialismIDsX", ToGoName(plurals))
+			assert.Equal(t, "pluralized_initialism_ids_x", ToFileName(plurals))
+		})
+
+		t.Run("with middle initialism", func(t *testing.T) {
+			const plurals = "pluralized IDs initialism"
+			lexems := s.split(plurals)
+			poolOfLexems.RedeemLexems(lexems)
+
+			require.NotNil(t, lexems)
+			require.Len(t, *lexems, 3)
+
+			assert.Equal(t, "PluralizedIDsInitialism", ToGoName(plurals))
+			assert.Equal(t, "pluralized_ids_initialism", ToFileName(plurals))
+		})
+
+		t.Run("with upper-cased pluralized initialism", func(t *testing.T) {
+			const plurals = "pluralized IDS initialism"
+			lexems := s.split(plurals)
+			poolOfLexems.RedeemLexems(lexems)
+
+			require.NotNil(t, lexems)
+			require.Len(t, *lexems, 4)
+
+			assert.Equal(t, "PluralizedIDSInitialism", ToGoName(plurals))
+			assert.Equal(t, "pluralized_id_s_initialism", ToFileName(plurals))
+		})
+
+		t.Run("with leading initialism", func(t *testing.T) {
+			const plurals = "IDs pluralized initialism"
+			lexems := s.split(plurals)
+			poolOfLexems.RedeemLexems(lexems)
+
+			require.NotNil(t, lexems)
+			require.Len(t, *lexems, 3)
+
+			assert.Equal(t, "IDsPluralizedInitialism", ToGoName(plurals))
+			assert.Equal(t, "ids_pluralized_initialism", ToFileName(plurals))
+		})
+
+		t.Run("with added non-default initialisms", func(t *testing.T) {
+			const plurals = "pluralized initialism ELBs"
+			lexems := s.split(plurals)
+			poolOfLexems.RedeemLexems(lexems)
+
+			require.NotNil(t, lexems)
+			require.Len(t, *lexems, 3)
+
+			assert.Equal(t, "PluralizedInitialismELBs", ToGoName(plurals))
+			assert.Equal(t, "pluralized_initialism_elbs", ToFileName(plurals))
+		})
+	})
+
+	t.Run("should recognize invariant initialisms", func(t *testing.T) {
+		t.Run("with explicit word boundary", func(t *testing.T) {
+			const plurals = "pluralized HTTP's initialism"
+			lexems := s.split(plurals)
+			poolOfLexems.RedeemLexems(lexems)
+
+			require.NotNil(t, lexems)
+			require.Len(t, *lexems, 4)
+
+			assert.Equal(t, "PluralizedHTTPsInitialism", ToGoName(plurals))
+			assert.Equal(t, "pluralized_http_s_initialism", ToFileName(plurals))
+		})
+
+		t.Run("with continued word", func(t *testing.T) {
+			t.Run("no initialism (invariant)", func(t *testing.T) {
+				const plurals = "pluralized HTTPs is not an initialism"
+				lexems := s.split(plurals)
+				poolOfLexems.RedeemLexems(lexems)
+
+				require.NotNil(t, lexems)
+				require.Len(t, *lexems, 9)
+				assert.Equal(t, "PluralizedHTTPsIsNotAnInitialism", ToGoName(plurals))
+				assert.Equal(t, "pluralizedHTTPsIsNotAnInitialism", ToVarName(plurals))
+				assert.Equal(t, "pluralized_h_t_t_ps_is_not_an_initialism", ToFileName(plurals))
+			})
+
+			t.Run("no initialism (pluralizable)", func(t *testing.T) {
+				const plurals = "pluralized ELBsis not an initialism"
+				lexems := s.split(plurals)
+				poolOfLexems.RedeemLexems(lexems)
+
+				require.NotNil(t, lexems)
+				require.Len(t, *lexems, 7)
+				assert.Equal(t, "PluralizedELBsisNotAnInitialism", ToGoName(plurals))
+				assert.Equal(t, "pluralizedELBsisNotAnInitialism", ToVarName(plurals))
+				assert.Equal(t, "pluralized_e_l_bsis_not_an_initialism", ToFileName(plurals))
+			})
+
+			t.Run("no initialism (no plural)", func(t *testing.T) {
+				const plurals = "pluralized ELBx is not an initialism"
+				lexems := s.split(plurals)
+				poolOfLexems.RedeemLexems(lexems)
+
+				require.NotNil(t, lexems)
+				require.Len(t, *lexems, 8)
+				assert.Equal(t, "PluralizedELBxIsNotAnInitialism", ToGoName(plurals))
+				assert.Equal(t, "pluralizedELBxIsNotAnInitialism", ToVarName(plurals))
+				assert.Equal(t, "pluralized_e_l_bx_is_not_an_initialism", ToFileName(plurals))
+			})
+
+			t.Run("with initialism trailed by lowercase", func(t *testing.T) {
+				const plurals = "pluralized initialism IDsx"
+				lexems := s.split(plurals)
+				poolOfLexems.RedeemLexems(lexems)
+
+				require.NotNil(t, lexems)
+				require.Len(t, *lexems, 4)
+
+				assert.Equal(t, "PluralizedInitialismIDsx", ToGoName(plurals))
+				assert.Equal(t, "pluralized_initialism_i_dsx", ToFileName(plurals))
+			})
+		})
+
+		t.Run("with proper case match: detect initialism", func(t *testing.T) {
+			const plurals = "pluralized HTTPS is an initialism"
+			lexems := s.split(plurals)
+			poolOfLexems.RedeemLexems(lexems)
+
+			require.NotNil(t, lexems)
+			require.Len(t, *lexems, 5)
+			assert.Equal(t, "PluralizedHTTPSIsAnInitialism", ToGoName(plurals))
+			assert.Equal(t, "pluralizedHTTPSIsAnInitialism", ToVarName(plurals))
+			assert.Equal(t, "pluralized_https_is_an_initialism", ToFileName(plurals))
+		})
+	})
+}
 
 func TestSplitter(t *testing.T) {
 	s := newSplitter(withPostSplitInitialismCheck)

--- a/util.go
+++ b/util.go
@@ -247,9 +247,8 @@ func ToGoName(name string) string {
 
 	// check if not starting with a letter, upper case
 	firstPart := lexemes[0].GetUnsafeGoName()
-	if lexemes[0].IsInitialism() {
-		firstPart = upper(firstPart)
-	}
+
+	// NOTE: no longer forcing the first part to be fully upper-cased
 
 	if c := firstPart[0]; c < utf8.RuneSelf {
 		// ASCII
@@ -272,10 +271,6 @@ func ToGoName(name string) string {
 			result.WriteString(prefixFunc(name, firstPart))
 		case !unicode.IsUpper(firstRune):
 			result.WriteString(prefixFunc(name, firstPart))
-			/*
-				result.WriteRune(unicode.ToUpper(firstRune))
-				result.WriteString(firstPart[offset:])
-			*/
 		default:
 			result.WriteString(firstPart)
 		}
@@ -284,10 +279,9 @@ func ToGoName(name string) string {
 	for _, lexem := range lexemes[1:] {
 		goName := lexem.GetUnsafeGoName()
 
-		// to support old behavior
-		if lexem.IsInitialism() {
-			goName = upper(goName)
-		}
+		// NOTE: no longer forcing initialism parts to be fully upper-cased:
+		// * pluralized initialism preserve their trailing "s"
+		// * mixed-cased initialisms, such as IPv4, are preserved
 		result.WriteString(goName)
 	}
 


### PR DESCRIPTION
Pluralized initialisms are of the simplest form, e.g. ID -> IDs.

Initialisms that end with an S (such as DNS) or that conflict with another initialism that ends with an S (such as HTTP) are invariant and do not support a pluralized form.

* fixes #46

Other changes that stem from newly supported initialisms that are not fully upper-cased:

* replaced IPV4 and IPV6 by IPv4 and IPv6
* now ToGoName doesn't force names like "IPv4Etc" in "IPV4Etc", but leaves the casing of IPv4.
* if it happens (by adding non default initialisms) that 2 initialisms differ only in case, the mixed-case one will be favored over the capitalized.