### PR TITLE
refact loading, jsonutils, yamlutils utililities

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -18,18 +18,32 @@
 //
 // Here is what is inside:
 //
-//	Sub-package conv:
-//	  - convert between value and pointers for builtin types
-//	  - convert from string to builtin types (wraps strconv)
+//				Package conv:
+//					* convert between value and pointers for builtin types
+//					* convert from string to builtin types (wraps strconv)
 //
-//	Package swag:
-//	- fast json concatenation
-//	- search in path
-//	- load from file or http
-//	- name mangling
+//				Package typeutils:
+//				  *  check the zero value for any type
 //
-// This repo has a few dependencies outside of the standard library:
+//				Package jsonutils:
+//				  * fast json concatenation
+//				  * read and write JSON from and to dynamic go data structures
 //
-//   - YAML utilities depend on [gopkg.in/yaml.v3]
+//				Package yamlutils:
+//				  * converting YAML to JSON
+//			    * loading YAML into a dynamic YAML document
+//
+//				Package loading:
+//				  * load from file or http
+//
+//				Package swag:
+//				  * search in path
+//		      * host, port from address
+//				  * name mangling
+//	       * file upload type
+//
+// This repo has only few dependencies outside of the standard library:
+//
+//   - YAML utilities depend on gopkg.in/yaml.v2
 //   - JSON utilities depend on [mailru/easyjson]
 package swag

--- a/jsonname.go
+++ b/jsonname.go
@@ -1,0 +1,146 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import (
+	"reflect"
+	"strings"
+	"sync"
+)
+
+// DefaultJSONNameProvider the default cache for types
+var DefaultJSONNameProvider = NewNameProvider()
+
+// NameProvider represents an object capable of translating from go property names
+// to json property names
+// This type is thread-safe.
+type NameProvider struct {
+	lock  *sync.Mutex
+	index map[reflect.Type]nameIndex
+}
+
+type nameIndex struct {
+	jsonNames map[string]string
+	goNames   map[string]string
+}
+
+// NewNameProvider creates a new name provider
+func NewNameProvider() *NameProvider {
+	return &NameProvider{
+		lock:  &sync.Mutex{},
+		index: make(map[reflect.Type]nameIndex),
+	}
+}
+
+func buildnameIndex(tpe reflect.Type, idx, reverseIdx map[string]string) {
+	for i := 0; i < tpe.NumField(); i++ {
+		targetDes := tpe.Field(i)
+
+		if targetDes.PkgPath != "" { // unexported
+			continue
+		}
+
+		if targetDes.Anonymous { // walk embedded structures tree down first
+			buildnameIndex(targetDes.Type, idx, reverseIdx)
+			continue
+		}
+
+		if tag := targetDes.Tag.Get("json"); tag != "" {
+
+			parts := strings.Split(tag, ",")
+			if len(parts) == 0 {
+				continue
+			}
+
+			nm := parts[0]
+			if nm == "-" {
+				continue
+			}
+			if nm == "" { // empty string means we want to use the Go name
+				nm = targetDes.Name
+			}
+
+			idx[nm] = targetDes.Name
+			reverseIdx[targetDes.Name] = nm
+		}
+	}
+}
+
+func newNameIndex(tpe reflect.Type) nameIndex {
+	var idx = make(map[string]string, tpe.NumField())
+	var reverseIdx = make(map[string]string, tpe.NumField())
+
+	buildnameIndex(tpe, idx, reverseIdx)
+	return nameIndex{jsonNames: idx, goNames: reverseIdx}
+}
+
+// GetJSONNames gets all the json property names for a type
+func (n *NameProvider) GetJSONNames(subject interface{}) []string {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	tpe := reflect.Indirect(reflect.ValueOf(subject)).Type()
+	names, ok := n.index[tpe]
+	if !ok {
+		names = n.makeNameIndex(tpe)
+	}
+
+	res := make([]string, 0, len(names.jsonNames))
+	for k := range names.jsonNames {
+		res = append(res, k)
+	}
+	return res
+}
+
+// GetJSONName gets the json name for a go property name
+func (n *NameProvider) GetJSONName(subject interface{}, name string) (string, bool) {
+	tpe := reflect.Indirect(reflect.ValueOf(subject)).Type()
+	return n.GetJSONNameForType(tpe, name)
+}
+
+// GetJSONNameForType gets the json name for a go property name on a given type
+func (n *NameProvider) GetJSONNameForType(tpe reflect.Type, name string) (string, bool) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	names, ok := n.index[tpe]
+	if !ok {
+		names = n.makeNameIndex(tpe)
+	}
+	nme, ok := names.goNames[name]
+	return nme, ok
+}
+
+func (n *NameProvider) makeNameIndex(tpe reflect.Type) nameIndex {
+	names := newNameIndex(tpe)
+	n.index[tpe] = names
+	return names
+}
+
+// GetGoName gets the go name for a json property name
+func (n *NameProvider) GetGoName(subject interface{}, name string) (string, bool) {
+	tpe := reflect.Indirect(reflect.ValueOf(subject)).Type()
+	return n.GetGoNameForType(tpe, name)
+}
+
+// GetGoNameForType gets the go name for a given type for a json property name
+func (n *NameProvider) GetGoNameForType(tpe reflect.Type, name string) (string, bool) {
+	n.lock.Lock()
+	defer n.lock.Unlock()
+	names, ok := n.index[tpe]
+	if !ok {
+		names = n.makeNameIndex(tpe)
+	}
+	nme, ok := names.jsonNames[name]
+	return nme, ok
+}

--- a/jsonname_test.go
+++ b/jsonname_test.go
@@ -1,0 +1,137 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type testNameStruct struct {
+	Name       string `json:"name"`
+	NotTheSame int64  `json:"plain"`
+	Ignored    string `json:"-"`
+}
+
+func TestNameProvider(t *testing.T) {
+	provider := NewNameProvider()
+
+	var obj = testNameStruct{}
+
+	nm, ok := provider.GetGoName(obj, "name")
+	assert.True(t, ok)
+	assert.Equal(t, "Name", nm)
+
+	nm, ok = provider.GetGoName(obj, "plain")
+	assert.True(t, ok)
+	assert.Equal(t, "NotTheSame", nm)
+
+	nm, ok = provider.GetGoName(obj, "doesNotExist")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetGoName(obj, "ignored")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	tpe := reflect.TypeOf(obj)
+	nm, ok = provider.GetGoNameForType(tpe, "name")
+	assert.True(t, ok)
+	assert.Equal(t, "Name", nm)
+
+	nm, ok = provider.GetGoNameForType(tpe, "plain")
+	assert.True(t, ok)
+	assert.Equal(t, "NotTheSame", nm)
+
+	nm, ok = provider.GetGoNameForType(tpe, "doesNotExist")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetGoNameForType(tpe, "ignored")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	ptr := &obj
+	nm, ok = provider.GetGoName(ptr, "name")
+	assert.True(t, ok)
+	assert.Equal(t, "Name", nm)
+
+	nm, ok = provider.GetGoName(ptr, "plain")
+	assert.True(t, ok)
+	assert.Equal(t, "NotTheSame", nm)
+
+	nm, ok = provider.GetGoName(ptr, "doesNotExist")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetGoName(ptr, "ignored")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetJSONName(obj, "Name")
+	assert.True(t, ok)
+	assert.Equal(t, "name", nm)
+
+	nm, ok = provider.GetJSONName(obj, "NotTheSame")
+	assert.True(t, ok)
+	assert.Equal(t, "plain", nm)
+
+	nm, ok = provider.GetJSONName(obj, "DoesNotExist")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetJSONName(obj, "Ignored")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetJSONNameForType(tpe, "Name")
+	assert.True(t, ok)
+	assert.Equal(t, "name", nm)
+
+	nm, ok = provider.GetJSONNameForType(tpe, "NotTheSame")
+	assert.True(t, ok)
+	assert.Equal(t, "plain", nm)
+
+	nm, ok = provider.GetJSONNameForType(tpe, "doesNotExist")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetJSONNameForType(tpe, "Ignored")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetJSONName(ptr, "Name")
+	assert.True(t, ok)
+	assert.Equal(t, "name", nm)
+
+	nm, ok = provider.GetJSONName(ptr, "NotTheSame")
+	assert.True(t, ok)
+	assert.Equal(t, "plain", nm)
+
+	nm, ok = provider.GetJSONName(ptr, "doesNotExist")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nm, ok = provider.GetJSONName(ptr, "Ignored")
+	assert.False(t, ok)
+	assert.Empty(t, nm)
+
+	nms := provider.GetJSONNames(ptr)
+	assert.Len(t, nms, 2)
+
+	assert.Len(t, provider.index, 1)
+}

--- a/jsonutils/json.go
+++ b/jsonutils/json.go
@@ -12,15 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swag
+package jsonutils
 
 import (
 	"bytes"
 	"encoding/json"
 	"log"
-	"reflect"
-	"strings"
-	"sync"
 
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
@@ -28,9 +25,6 @@ import (
 
 // nullJSON represents a JSON object with null type
 var nullJSON = []byte("null")
-
-// DefaultJSONNameProvider the default cache for types
-var DefaultJSONNameProvider = NewNameProvider()
 
 const comma = byte(',')
 
@@ -188,126 +182,4 @@ func FromDynamicJSON(data, target interface{}) error {
 		log.Println(err)
 	}
 	return json.Unmarshal(b, target)
-}
-
-// NameProvider represents an object capable of translating from go property names
-// to json property names
-// This type is thread-safe.
-type NameProvider struct {
-	lock  *sync.Mutex
-	index map[reflect.Type]nameIndex
-}
-
-type nameIndex struct {
-	jsonNames map[string]string
-	goNames   map[string]string
-}
-
-// NewNameProvider creates a new name provider
-func NewNameProvider() *NameProvider {
-	return &NameProvider{
-		lock:  &sync.Mutex{},
-		index: make(map[reflect.Type]nameIndex),
-	}
-}
-
-func buildnameIndex(tpe reflect.Type, idx, reverseIdx map[string]string) {
-	for i := 0; i < tpe.NumField(); i++ {
-		targetDes := tpe.Field(i)
-
-		if targetDes.PkgPath != "" { // unexported
-			continue
-		}
-
-		if targetDes.Anonymous { // walk embedded structures tree down first
-			buildnameIndex(targetDes.Type, idx, reverseIdx)
-			continue
-		}
-
-		if tag := targetDes.Tag.Get("json"); tag != "" {
-
-			parts := strings.Split(tag, ",")
-			if len(parts) == 0 {
-				continue
-			}
-
-			nm := parts[0]
-			if nm == "-" {
-				continue
-			}
-			if nm == "" { // empty string means we want to use the Go name
-				nm = targetDes.Name
-			}
-
-			idx[nm] = targetDes.Name
-			reverseIdx[targetDes.Name] = nm
-		}
-	}
-}
-
-func newNameIndex(tpe reflect.Type) nameIndex {
-	var idx = make(map[string]string, tpe.NumField())
-	var reverseIdx = make(map[string]string, tpe.NumField())
-
-	buildnameIndex(tpe, idx, reverseIdx)
-	return nameIndex{jsonNames: idx, goNames: reverseIdx}
-}
-
-// GetJSONNames gets all the json property names for a type
-func (n *NameProvider) GetJSONNames(subject interface{}) []string {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-	tpe := reflect.Indirect(reflect.ValueOf(subject)).Type()
-	names, ok := n.index[tpe]
-	if !ok {
-		names = n.makeNameIndex(tpe)
-	}
-
-	res := make([]string, 0, len(names.jsonNames))
-	for k := range names.jsonNames {
-		res = append(res, k)
-	}
-	return res
-}
-
-// GetJSONName gets the json name for a go property name
-func (n *NameProvider) GetJSONName(subject interface{}, name string) (string, bool) {
-	tpe := reflect.Indirect(reflect.ValueOf(subject)).Type()
-	return n.GetJSONNameForType(tpe, name)
-}
-
-// GetJSONNameForType gets the json name for a go property name on a given type
-func (n *NameProvider) GetJSONNameForType(tpe reflect.Type, name string) (string, bool) {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-	names, ok := n.index[tpe]
-	if !ok {
-		names = n.makeNameIndex(tpe)
-	}
-	nme, ok := names.goNames[name]
-	return nme, ok
-}
-
-func (n *NameProvider) makeNameIndex(tpe reflect.Type) nameIndex {
-	names := newNameIndex(tpe)
-	n.index[tpe] = names
-	return names
-}
-
-// GetGoName gets the go name for a json property name
-func (n *NameProvider) GetGoName(subject interface{}, name string) (string, bool) {
-	tpe := reflect.Indirect(reflect.ValueOf(subject)).Type()
-	return n.GetGoNameForType(tpe, name)
-}
-
-// GetGoNameForType gets the go name for a given type for a json property name
-func (n *NameProvider) GetGoNameForType(tpe reflect.Type, name string) (string, bool) {
-	n.lock.Lock()
-	defer n.lock.Unlock()
-	names, ok := n.index[tpe]
-	if !ok {
-		names = n.makeNameIndex(tpe)
-	}
-	nme, ok := names.jsonNames[name]
-	return nme, ok
 }

--- a/jsonutils/json_test.go
+++ b/jsonutils/json_test.go
@@ -12,132 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swag
+package jsonutils
 
 import (
-	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
-
-type testNameStruct struct {
-	Name       string `json:"name"`
-	NotTheSame int64  `json:"plain"`
-	Ignored    string `json:"-"`
-}
-
-func TestNameProvider(t *testing.T) {
-
-	provider := NewNameProvider()
-
-	var obj = testNameStruct{}
-
-	nm, ok := provider.GetGoName(obj, "name")
-	assert.True(t, ok)
-	assert.Equal(t, "Name", nm)
-
-	nm, ok = provider.GetGoName(obj, "plain")
-	assert.True(t, ok)
-	assert.Equal(t, "NotTheSame", nm)
-
-	nm, ok = provider.GetGoName(obj, "doesNotExist")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetGoName(obj, "ignored")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	tpe := reflect.TypeOf(obj)
-	nm, ok = provider.GetGoNameForType(tpe, "name")
-	assert.True(t, ok)
-	assert.Equal(t, "Name", nm)
-
-	nm, ok = provider.GetGoNameForType(tpe, "plain")
-	assert.True(t, ok)
-	assert.Equal(t, "NotTheSame", nm)
-
-	nm, ok = provider.GetGoNameForType(tpe, "doesNotExist")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetGoNameForType(tpe, "ignored")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	ptr := &obj
-	nm, ok = provider.GetGoName(ptr, "name")
-	assert.True(t, ok)
-	assert.Equal(t, "Name", nm)
-
-	nm, ok = provider.GetGoName(ptr, "plain")
-	assert.True(t, ok)
-	assert.Equal(t, "NotTheSame", nm)
-
-	nm, ok = provider.GetGoName(ptr, "doesNotExist")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetGoName(ptr, "ignored")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetJSONName(obj, "Name")
-	assert.True(t, ok)
-	assert.Equal(t, "name", nm)
-
-	nm, ok = provider.GetJSONName(obj, "NotTheSame")
-	assert.True(t, ok)
-	assert.Equal(t, "plain", nm)
-
-	nm, ok = provider.GetJSONName(obj, "DoesNotExist")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetJSONName(obj, "Ignored")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetJSONNameForType(tpe, "Name")
-	assert.True(t, ok)
-	assert.Equal(t, "name", nm)
-
-	nm, ok = provider.GetJSONNameForType(tpe, "NotTheSame")
-	assert.True(t, ok)
-	assert.Equal(t, "plain", nm)
-
-	nm, ok = provider.GetJSONNameForType(tpe, "doesNotExist")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetJSONNameForType(tpe, "Ignored")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetJSONName(ptr, "Name")
-	assert.True(t, ok)
-	assert.Equal(t, "name", nm)
-
-	nm, ok = provider.GetJSONName(ptr, "NotTheSame")
-	assert.True(t, ok)
-	assert.Equal(t, "plain", nm)
-
-	nm, ok = provider.GetJSONName(ptr, "doesNotExist")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nm, ok = provider.GetJSONName(ptr, "Ignored")
-	assert.False(t, ok)
-	assert.Empty(t, nm)
-
-	nms := provider.GetJSONNames(ptr)
-	assert.Len(t, nms, 2)
-
-	assert.Len(t, provider.index, 1)
-
-}
 
 //nolint:testifylint
 func TestJSONConcatenation(t *testing.T) {

--- a/jsonutils_iface.go
+++ b/jsonutils_iface.go
@@ -1,0 +1,49 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import "github.com/go-openapi/swag/jsonutils"
+
+// WriteJSON writes json data.
+//
+// See [jsonutils.WriteJSON]
+func WriteJSON(data interface{}) ([]byte, error) { return jsonutils.WriteJSON(data) }
+
+// ReadJSON reads json data.
+//
+// Deprecated: use [jsonutils.ReadJSON] instead.
+func ReadJSON(data []byte, value interface{}) error { return jsonutils.ReadJSON(data, value) }
+
+// DynamicJSONToStruct converts an untyped json structure into a struct.
+//
+// Deprecated: use [jsonutils.DynamicJSONToStruct] instead.
+func DynamicJSONToStruct(data interface{}, target interface{}) error {
+	return jsonutils.DynamicJSONToStruct(data, target)
+}
+
+// ConcatJSON concatenates multiple json objects efficiently.
+//
+// Deprecated: use [jsonutils.ConcatJSON] instead.
+func ConcatJSON(blobs ...[]byte) []byte { return jsonutils.ConcatJSON(blobs...) }
+
+// ToDynamicJSON turns an object into a properly JSON typed structure.
+//
+// Deprecated: use [jsonutils.ToDynamicJSON] instead.
+func ToDynamicJSON(data interface{}) interface{} { return jsonutils.ToDynamicJSON(data) }
+
+// FromDynamicJSON turns an object into a properly JSON typed structure.
+//
+// Deprecated: use [jsonutils.FromDynamicJSON] instead.
+func FromDynamicJSON(data, target interface{}) error { return jsonutils.FromDynamicJSON(data, target) }

--- a/jsonutils_iface_test.go
+++ b/jsonutils_iface_test.go
@@ -1,0 +1,70 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestJSONUtilsIface(t *testing.T) {
+	t.Run("deprecated functions should work", func(t *testing.T) {
+		t.Run("ReadJSON and WriteJSON back", func(t *testing.T) {
+			var b any
+
+			const jazon = `{"a": 1}`
+			require.NoError(t, ReadJSON([]byte(jazon), &b))
+
+			buf, err := WriteJSON(b)
+			require.NoError(t, err)
+			require.JSONEq(t, jazon, string(buf))
+		})
+
+		t.Run("ConcatJSON merge 2 objects", func(t *testing.T) {
+			buf := ConcatJSON([]byte(`{"a": 1}`), []byte(`{"b": 2}`))
+			require.JSONEq(t, `{"a": 1, "b": 2}`, string(buf))
+		})
+
+		t.Run("with go struct", func(t *testing.T) {
+			var a struct {
+				A int
+			}
+			a.A = 1
+
+			t.Run("FromDynamicJSON into a map", func(t *testing.T) {
+				var b any
+
+				require.NoError(t, FromDynamicJSON(a, &b))
+
+				_, isMap := b.(map[string]any)
+				assert.True(t, isMap)
+			})
+
+			t.Run("ToDynamicJSON into a map", func(t *testing.T) {
+				c := ToDynamicJSON(a)
+				_, isMap := c.(map[string]any)
+				assert.True(t, isMap)
+
+				t.Run("DynamicJSONToStruct back to struct", func(t *testing.T) {
+					a.A = 0
+					require.NoError(t, DynamicJSONToStruct(c, &a))
+					assert.Equalf(t, 1, a.A, "expected to restore original value")
+				})
+			})
+		})
+	})
+}

--- a/loading/doc.go
+++ b/loading/doc.go
@@ -4,7 +4,7 @@
 // you may not use this file except in compliance with the License.
 // You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -12,18 +12,5 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swag
-
-type swagError string
-
-const (
-	// ErrYAML is an error raised by YAML utilities
-	ErrYAML swagError = "yaml error"
-
-	// ErrLoader is an error raised by the file loader utility
-	ErrLoader swagError = "loader error"
-)
-
-func (e swagError) Error() string {
-	return string(e)
-}
+// Package loading provides tools to load a file from http or a local file.
+package loading

--- a/loading/errors.go
+++ b/loading/errors.go
@@ -1,0 +1,26 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loading
+
+type loadingError string
+
+const (
+	// ErrLoader is an error raised by the file loader utility
+	ErrLoader loadingError = "loader error"
+)
+
+func (e loadingError) Error() string {
+	return string(e)
+}

--- a/loading/loading.go
+++ b/loading/loading.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swag
+package loading
 
 import (
 	"context"
@@ -25,43 +25,12 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
-	"time"
 )
 
-// LoadHTTPTimeout the default timeout for load requests
-//
-// Deprecated: use [LoadingWithTimeout] option instead.
-var LoadHTTPTimeout = 30 * time.Second
-
-// LoadHTTPBasicAuthUsername the username to use when load requests require basic auth
-//
-// Deprecated: use [LoadingWithBasicAuth] option instead.
-var LoadHTTPBasicAuthUsername = ""
-
-// LoadHTTPBasicAuthPassword the password to use when load requests require basic auth
-//
-// Deprecated: use [LoadingWithBasicAuth] option instead.
-var LoadHTTPBasicAuthPassword = ""
-
-// LoadHTTPCustomHeaders an optional collection of custom HTTP headers for load requests
-//
-// Deprecated: use [LoadingWithCustomHeaders] option instead.
-var LoadHTTPCustomHeaders = map[string]string{}
-
 // LoadFromFileOrHTTP loads the bytes from a file or a remote http server based on the path passed in
-func LoadFromFileOrHTTP(pth string, opts ...LoadingOption) ([]byte, error) {
-	o := loadingOptionsWithDefaults(opts)
+func LoadFromFileOrHTTP(pth string, opts ...Option) ([]byte, error) {
+	o := optionsWithDefaults(opts)
 	return LoadStrategy(pth, o.ReadFileFunc(), loadHTTPBytes(opts...), opts...)(pth)
-}
-
-// LoadFromFileOrHTTPWithTimeout loads the bytes from a file or a remote http server based on the path passed in
-// timeout arg allows for per request overriding of the request timeout.
-//
-// Deprecated: use LoadFromFileOrHTTP with the [LoadingWithTimeout] option instead.
-func LoadFromFileOrHTTPWithTimeout(pth string, timeout time.Duration, opts ...LoadingOption) ([]byte, error) {
-	opts = append(opts, LoadingWithTimeout(timeout))
-
-	return LoadFromFileOrHTTP(pth, opts...)
 }
 
 // LoadStrategy returns a loader function for a given path or URI.
@@ -94,7 +63,7 @@ func LoadFromFileOrHTTPWithTimeout(pth string, timeout time.Duration, opts ...Lo
 // - `file://host/folder/file` becomes an UNC path like `\\host\folder\file` (no port specification is supported)
 // - `file:///c:/folder/file` becomes `C:\folder\file`
 // - `file://c:/folder/file` is tolerated (without leading `/`) and becomes `c:\folder\file`
-func LoadStrategy(pth string, local, remote func(string) ([]byte, error), _ ...LoadingOption) func(string) ([]byte, error) {
+func LoadStrategy(pth string, local, remote func(string) ([]byte, error), _ ...Option) func(string) ([]byte, error) {
 	if strings.HasPrefix(pth, "http") {
 		return remote
 	}
@@ -152,8 +121,8 @@ func LoadStrategy(pth string, local, remote func(string) ([]byte, error), _ ...L
 	}
 }
 
-func loadHTTPBytes(opts ...LoadingOption) func(path string) ([]byte, error) {
-	o := loadingOptionsWithDefaults(opts)
+func loadHTTPBytes(opts ...Option) func(path string) ([]byte, error) {
+	o := optionsWithDefaults(opts)
 
 	return func(path string) ([]byte, error) {
 		client := o.client

--- a/loading/petstore_fixture.yaml
+++ b/loading/petstore_fixture.yaml
@@ -1,0 +1,154 @@
+swagger: '2.0'
+info:
+  version: '1.0.0'
+  title: Swagger Petstore
+  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
+  termsOfService: http://helloreverb.com/terms/
+  contact:
+    name: Swagger API team
+    email: foo@example.com
+    url: http://swagger.io
+  license:
+    name: MIT
+    url: http://opensource.org/licenses/MIT
+host: petstore.swagger.wordnik.com
+basePath: /api
+schemes:
+  - http
+consumes:
+  - application/json
+produces:
+  - application/json
+paths:
+  /pets:
+    get:
+      description: Returns all pets from the system that the user has access to
+      operationId: findPets
+      produces:
+        - application/json
+        - application/xml
+        - text/xml
+        - text/html
+      parameters:
+        - name: tags
+          in: query
+          description: tags to filter by
+          required: false
+          type: array
+          items:
+            type: string
+          collectionFormat: csv
+        - name: limit
+          in: query
+          description: maximum number of results to return
+          required: false
+          type: integer
+          format: int32
+      responses:
+        '200':
+          description: pet response
+          schema:
+            type: array
+            items:
+              $ref: '#/definitions/pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/errorModel'
+    post:
+      description: Creates a new pet in the store.  Duplicates are allowed
+      operationId: addPet
+      produces:
+        - application/json
+      parameters:
+        - name: pet
+          in: body
+          description: Pet to add to the store
+          required: true
+          schema:
+            $ref: '#/definitions/newPet'
+      responses:
+        '200':
+          description: pet response
+          schema:
+            $ref: '#/definitions/pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/errorModel'
+  /pets/{id}:
+    get:
+      description: Returns a user based on a single ID, if the user does not have access to the pet
+      operationId: findPetById
+      produces:
+        - application/json
+        - application/xml
+        - text/xml
+        - text/html
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to fetch
+          required: true
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: pet response
+          schema:
+            $ref: '#/definitions/pet'
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/errorModel'
+    delete:
+      description: deletes a single pet based on the ID supplied
+      operationId: deletePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to delete
+          required: true
+          type: integer
+          format: int64
+      responses:
+        '204':
+          description: pet deleted
+        default:
+          description: unexpected error
+          schema:
+            $ref: '#/definitions/errorModel'
+definitions:
+  pet:
+    required:
+      - id
+      - name
+    properties:
+      id:
+        type: integer
+        format: int64
+      name:
+        type: string
+      tag:
+        type: string
+  newPet:
+    allOf:
+      - $ref: '#/definitions/pet'
+      - required:
+          - name
+        properties:
+          id:
+            type: integer
+            format: int64
+          name:
+            type: string
+  errorModel:
+    required:
+      - code
+      - message
+    properties:
+      code:
+        type: integer
+        format: int32
+      message:
+        type: string

--- a/loading/serve_test.go
+++ b/loading/serve_test.go
@@ -1,0 +1,88 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loading
+
+import (
+	"embed"
+	"fmt"
+	"net/http"
+)
+
+// embedded test files
+
+//go:embed petstore_fixture.yaml
+var embeddedFixtures embed.FS
+
+// YAMLPetStore embeds the classical pet store API swagger example.
+var YAMLPetStore []byte
+
+func init() {
+	data, err := embeddedFixtures.ReadFile("petstore_fixture.yaml")
+	if err != nil {
+		panic(fmt.Errorf("wrong embedded FS configuration: %w", err))
+	}
+
+	YAMLPetStore = data
+}
+
+// test handlers
+
+// serveYAMLPestore is a http handler to serve the YAMLPestore doc.
+func serveYAMLPestore(rw http.ResponseWriter, _ *http.Request) {
+	rw.WriteHeader(http.StatusOK)
+	_, _ = rw.Write(YAMLPetStore)
+}
+
+func serveOK(rw http.ResponseWriter, _ *http.Request) {
+	rw.WriteHeader(http.StatusOK)
+	_, _ = rw.Write([]byte("the content"))
+}
+
+func serveKO(rw http.ResponseWriter, _ *http.Request) {
+	rw.WriteHeader(http.StatusNotFound)
+}
+
+func serveBasicAuthFunc(user, password string) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		u, p, ok := r.BasicAuth()
+		if ok && u == user && p == password {
+			rw.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		rw.WriteHeader(http.StatusForbidden)
+	}
+}
+
+func serveRequireHeaderFunc(key, value string) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		myHeaders := r.Header[key]
+		ok := false
+		for _, v := range myHeaders {
+			if v == value {
+				ok = true
+				break
+			}
+		}
+		if ok {
+			rw.WriteHeader(http.StatusOK)
+
+			return
+		}
+
+		rw.WriteHeader(http.StatusForbidden)
+	}
+}

--- a/loading/yaml.go
+++ b/loading/yaml.go
@@ -1,0 +1,53 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package loading
+
+import (
+	"encoding/json"
+	"path/filepath"
+
+	"github.com/go-openapi/swag/yamlutils"
+)
+
+// YAMLMatcher matches yaml for a file loader.
+func YAMLMatcher(path string) bool {
+	ext := filepath.Ext(path)
+	return ext == ".yaml" || ext == ".yml"
+}
+
+// YAMLDoc loads a yaml document from either http or a file and converts it to json.
+func YAMLDoc(path string, opts ...Option) (json.RawMessage, error) {
+	yamlDoc, err := YAMLData(path, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	data, err := yamlutils.YAMLToJSON(yamlDoc)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+// YAMLData loads a yaml document from either http or a file.
+func YAMLData(path string, opts ...Option) (interface{}, error) {
+	data, err := LoadFromFileOrHTTP(path, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return yamlutils.BytesToYAMLDoc(data)
+}

--- a/loading/yaml_test.go
+++ b/loading/yaml_test.go
@@ -1,0 +1,40 @@
+package loading
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestYAMLMatcher(t *testing.T) {
+	t.Run("should recognize a yaml file", func(t *testing.T) {
+		assert.True(t, YAMLMatcher("local.yml"))
+		assert.True(t, YAMLMatcher("local.yaml"))
+		assert.False(t, YAMLMatcher("local.json"))
+	})
+}
+
+func TestYAMLDoc(t *testing.T) {
+	t.Run("should retrieve pet store API as YAML", func(t *testing.T) {
+		serv := httptest.NewServer(http.HandlerFunc(serveYAMLPestore))
+		defer serv.Close()
+
+		s, err := YAMLDoc(serv.URL)
+		require.NoError(t, err)
+		require.NotNil(t, s)
+	})
+
+	t.Run("should not retrieve any doc", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+			rw.WriteHeader(http.StatusNotFound)
+			_, _ = rw.Write([]byte("\n"))
+		}))
+		defer ts.Close()
+
+		_, err := YAMLDoc(ts.URL)
+		require.Error(t, err)
+	})
+}

--- a/loading_iface.go
+++ b/loading_iface.go
@@ -1,0 +1,102 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/go-openapi/swag/loading"
+)
+
+var (
+	// Package-level defaults for the file loading utilities (deprecated).
+
+	// LoadHTTPTimeout the default timeout for load requests.
+	//
+	// Deprecated: use [loading.WithTimeout] instead.
+	LoadHTTPTimeout = 30 * time.Second
+
+	// LoadHTTPBasicAuthUsername the username to use when load requests require basic auth.
+	//
+	// Deprecated: use [loading.WithBasicAuth] instead.
+	LoadHTTPBasicAuthUsername = ""
+
+	// LoadHTTPBasicAuthPassword the password to use when load requests require basic auth.
+	//
+	// Deprecated: use [loading.WithBasicAuth] instead.
+	LoadHTTPBasicAuthPassword = ""
+
+	// LoadHTTPCustomHeaders an optional collection of custom HTTP headers for load requests.
+	//
+	// Deprecated: use [loading.WithCustomHeaders] instead.
+	LoadHTTPCustomHeaders = map[string]string{}
+)
+
+// LoadFromFileOrHTTP loads the bytes from a file or a remote http server based on the provided path.
+//
+// Deprecated: use [loading.LoadFromFileOrHTTP] instead.
+func LoadFromFileOrHTTP(pth string, opts ...loading.Option) ([]byte, error) {
+	return loading.LoadFromFileOrHTTP(pth, loadingOptionsWithDefaults(opts)...)
+}
+
+// LoadFromFileOrHTTPWithTimeout loads the bytes from a file or a remote http server based on the path passed in
+// timeout arg allows for per request overriding of the request timeout.
+//
+// Deprecated: use [loading.LoadFileOrHTTP] with the [loading.WithTimeout] option instead.
+func LoadFromFileOrHTTPWithTimeout(pth string, timeout time.Duration, opts ...loading.Option) ([]byte, error) {
+	opts = append(opts, loading.WithTimeout(timeout))
+
+	return LoadFromFileOrHTTP(pth, opts...)
+}
+
+// LoadStrategy returns a loader function for a given path or URL.
+//
+// Deprecated: use [loading.LoadStrategy] instead.
+func LoadStrategy(pth string, local, remote func(string) ([]byte, error), opts ...loading.Option) func(string) ([]byte, error) {
+	return loading.LoadStrategy(pth, local, remote, loadingOptionsWithDefaults(opts)...)
+}
+
+// YAMLMatcher matches yaml for a file loader.
+//
+// Deprecated: use [loading.YAMLMatcher] instead.
+func YAMLMatcher(path string) bool { return loading.YAMLMatcher(path) }
+
+// YAMLDoc loads a yaml document from either http or a file and converts it to json.
+//
+// Deprecated: use [loading.YAMLDoc] instead.
+func YAMLDoc(path string, opts ...loading.Option) (json.RawMessage, error) {
+	return loading.YAMLDoc(path, opts...)
+}
+
+// YAMLData loads a yaml document from either http or a file.
+//
+// Deprecated: use [loading.YAMLData] instead.
+func YAMLData(path string, opts ...loading.Option) (interface{}, error) {
+	return loading.YAMLData(path, opts...)
+}
+
+// loadingOptionsWithDefaults bridges deprecated default settings that use package-level variables,
+// with the recommended use of loading.Option.
+func loadingOptionsWithDefaults(opts []loading.Option) []loading.Option {
+	o := []loading.Option{
+		loading.WithTimeout(LoadHTTPTimeout),
+		loading.WithBasicAuth(LoadHTTPBasicAuthUsername, LoadHTTPBasicAuthPassword),
+		loading.WithCustomHeaders(LoadHTTPCustomHeaders),
+	}
+	o = append(o, opts...)
+
+	return o
+}

--- a/loading_iface_test.go
+++ b/loading_iface_test.go
@@ -1,0 +1,154 @@
+package swag
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLoadFromHTTP(t *testing.T) {
+	// Check backward-compatible global config.
+	// More comprehensive testing is carried out in package loading.
+
+	t.Run("with remote basic auth", func(t *testing.T) {
+		const (
+			validUsername   = "fake-user"
+			validPassword   = "correct-password"
+			invalidPassword = "incorrect-password"
+		)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			u, p, ok := r.BasicAuth()
+			if ok && u == validUsername && p == validPassword {
+				rw.WriteHeader(http.StatusOK)
+
+				return
+			}
+
+			rw.WriteHeader(http.StatusForbidden)
+		}))
+		defer ts.Close()
+
+		t.Run("using global config", func(t *testing.T) {
+			t.Cleanup(func() {
+				LoadHTTPBasicAuthUsername = ""
+				LoadHTTPBasicAuthPassword = ""
+			})
+
+			t.Run("should load from remote URL with basic auth", func(t *testing.T) {
+				// basic auth, valid credentials
+				LoadHTTPBasicAuthUsername = validUsername
+				LoadHTTPBasicAuthPassword = validPassword
+
+				_, err := LoadFromFileOrHTTP(ts.URL)
+				require.NoError(t, err)
+			})
+		})
+	})
+
+	t.Run("with remote API key auth", func(t *testing.T) {
+		const (
+			sharedHeaderKey   = "X-Myapp"
+			sharedHeaderValue = "MySecretKey"
+		)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			myHeaders := r.Header[sharedHeaderKey]
+			ok := false
+			for _, v := range myHeaders {
+				if v == sharedHeaderValue {
+					ok = true
+					break
+				}
+			}
+			if ok {
+				rw.WriteHeader(http.StatusOK)
+			} else {
+				rw.WriteHeader(http.StatusForbidden)
+			}
+		}))
+		defer ts.Close()
+
+		t.Run("using global config", func(t *testing.T) {
+			t.Cleanup(func() {
+				LoadHTTPCustomHeaders = map[string]string{}
+			})
+
+			t.Run("should load from remote URL with API key header", func(t *testing.T) {
+				LoadHTTPCustomHeaders[sharedHeaderKey] = sharedHeaderValue
+
+				_, err := LoadFromFileOrHTTP(ts.URL)
+				require.NoError(t, err)
+			})
+		})
+	})
+
+	t.Run("should not load when timeout", func(t *testing.T) {
+		const (
+			delay = 30 * time.Millisecond
+			wait  = delay / 2
+		)
+
+		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+			time.Sleep(delay)
+			rw.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		t.Run("using global configuration", func(t *testing.T) {
+			original := LoadHTTPTimeout
+			t.Cleanup(func() {
+				LoadHTTPTimeout = original
+			})
+			LoadHTTPTimeout = wait
+
+			_, err := LoadFromFileOrHTTP(ts.URL)
+			require.Error(t, err)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		})
+
+		t.Run("using deprecated method", func(t *testing.T) {
+			_, err := LoadFromFileOrHTTPWithTimeout(ts.URL, wait)
+			require.Error(t, err)
+			require.ErrorIs(t, err, context.DeadlineExceeded)
+		})
+
+		t.Run("should serve local strategy", func(t *testing.T) {
+			loader := func(_ string) ([]byte, error) {
+				return []byte("local"), nil
+			}
+			remLoader := func(_ string) ([]byte, error) {
+				return []byte("remote"), nil
+			}
+			ldr := LoadStrategy("not_http", loader, remLoader)
+			b, _ := ldr("")
+			assert.Equal(t, "local", string(b))
+		})
+	})
+}
+
+func TestYAMLDoc(t *testing.T) {
+	t.Run("deprecated loading YAML functions should work", func(t *testing.T) {
+		require.True(t, YAMLMatcher("a.yml"))
+
+		ts := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, _ *http.Request) {
+			rw.WriteHeader(http.StatusOK)
+			const ydoc = "x:\n  a: one\n  b: two\n"
+			_, _ = rw.Write([]byte(ydoc))
+		}))
+		defer ts.Close()
+
+		b, err := YAMLDoc(ts.URL)
+		require.NoError(t, err)
+		require.NotEmpty(t, b)
+
+		doc, err := YAMLData(ts.URL)
+		require.NoError(t, err)
+		require.NotEmpty(t, doc)
+	})
+}

--- a/yamlutils/errors.go
+++ b/yamlutils/errors.go
@@ -1,0 +1,12 @@
+package yamlutils
+
+type yamlError string
+
+const (
+	// ErrYAML is an error raised by YAML utilities
+	ErrYAML yamlError = "yaml error"
+)
+
+func (e yamlError) Error() string {
+	return string(e)
+}

--- a/yamlutils/yaml.go
+++ b/yamlutils/yaml.go
@@ -12,26 +12,20 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swag
+package yamlutils
 
 import (
-	"encoding/json"
+	json "encoding/json"
 	"fmt"
-	"path/filepath"
 	"reflect"
 	"sort"
 	"strconv"
 
+	"github.com/go-openapi/swag/jsonutils"
 	"github.com/mailru/easyjson/jlexer"
 	"github.com/mailru/easyjson/jwriter"
 	yaml "gopkg.in/yaml.v3"
 )
-
-// YAMLMatcher matches yaml
-func YAMLMatcher(path string) bool {
-	ext := filepath.Ext(path)
-	return ext == ".yaml" || ext == ".yml"
-}
 
 // YAMLToJSON converts YAML unmarshaled data into json compatible data
 func YAMLToJSON(data interface{}) (json.RawMessage, error) {
@@ -39,7 +33,7 @@ func YAMLToJSON(data interface{}) (json.RawMessage, error) {
 	if err != nil {
 		return nil, err
 	}
-	b, err := WriteJSON(jm)
+	b, err := jsonutils.WriteJSON(jm)
 	return json.RawMessage(b), err
 }
 
@@ -168,7 +162,7 @@ func yamlStringScalarC(node *yaml.Node) (string, error) {
 	}
 }
 
-// JSONMapSlice represent a JSON object, with the order of keys maintained
+// JSONMapSlice represents a JSON object, with the order of keys maintained
 type JSONMapSlice []JSONMapItem
 
 // MarshalJSON renders a JSONMapSlice as JSON
@@ -370,7 +364,7 @@ func (s JSONMapItem) MarshalJSON() ([]byte, error) {
 func (s JSONMapItem) MarshalEasyJSON(w *jwriter.Writer) {
 	w.String(s.Key)
 	w.RawByte(':')
-	w.Raw(WriteJSON(s.Value))
+	w.Raw(jsonutils.WriteJSON(s.Value))
 }
 
 // UnmarshalJSON makes a JSONMapItem from JSON
@@ -453,29 +447,4 @@ func transformData(input interface{}) (out interface{}, err error) {
 		return o, nil
 	}
 	return input, nil
-}
-
-// YAMLDoc loads a yaml document from either http or a file and converts it to json
-func YAMLDoc(path string) (json.RawMessage, error) {
-	yamlDoc, err := YAMLData(path)
-	if err != nil {
-		return nil, err
-	}
-
-	data, err := YAMLToJSON(yamlDoc)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
-}
-
-// YAMLData loads a yaml document from either http or a file
-func YAMLData(path string) (interface{}, error) {
-	data, err := LoadFromFileOrHTTP(path)
-	if err != nil {
-		return nil, err
-	}
-
-	return BytesToYAMLDoc(data)
 }

--- a/yamlutils/yaml_test.go
+++ b/yamlutils/yaml_test.go
@@ -12,11 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package swag
+package yamlutils
 
 import (
-	"encoding/json"
-	"net/http"
+	json "encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -199,11 +198,6 @@ name: a string value
 	d, err = YAMLToJSON(dd)
 	require.NoError(t, err)
 	assert.JSONEq(t, `{"description":"object created"}`, string(d))
-}
-
-var yamlPestoreServer = func(rw http.ResponseWriter, _ *http.Request) {
-	rw.WriteHeader(http.StatusOK)
-	_, _ = rw.Write([]byte(yamlPetStore))
 }
 
 func TestWithYKey(t *testing.T) {
@@ -530,160 +524,4 @@ produces:
 schemes:
 - https
 swagger: "2.0"
-`
-
-const yamlPetStore = `swagger: '2.0'
-info:
-  version: '1.0.0'
-  title: Swagger Petstore
-  description: A sample API that uses a petstore as an example to demonstrate features in the swagger-2.0 specification
-  termsOfService: http://helloreverb.com/terms/
-  contact:
-    name: Swagger API team
-    email: foo@example.com
-    url: http://swagger.io
-  license:
-    name: MIT
-    url: http://opensource.org/licenses/MIT
-host: petstore.swagger.wordnik.com
-basePath: /api
-schemes:
-  - http
-consumes:
-  - application/json
-produces:
-  - application/json
-paths:
-  /pets:
-    get:
-      description: Returns all pets from the system that the user has access to
-      operationId: findPets
-      produces:
-        - application/json
-        - application/xml
-        - text/xml
-        - text/html
-      parameters:
-        - name: tags
-          in: query
-          description: tags to filter by
-          required: false
-          type: array
-          items:
-            type: string
-          collectionFormat: csv
-        - name: limit
-          in: query
-          description: maximum number of results to return
-          required: false
-          type: integer
-          format: int32
-      responses:
-        '200':
-          description: pet response
-          schema:
-            type: array
-            items:
-              $ref: '#/definitions/pet'
-        default:
-          description: unexpected error
-          schema:
-            $ref: '#/definitions/errorModel'
-    post:
-      description: Creates a new pet in the store.  Duplicates are allowed
-      operationId: addPet
-      produces:
-        - application/json
-      parameters:
-        - name: pet
-          in: body
-          description: Pet to add to the store
-          required: true
-          schema:
-            $ref: '#/definitions/newPet'
-      responses:
-        '200':
-          description: pet response
-          schema:
-            $ref: '#/definitions/pet'
-        default:
-          description: unexpected error
-          schema:
-            $ref: '#/definitions/errorModel'
-  /pets/{id}:
-    get:
-      description: Returns a user based on a single ID, if the user does not have access to the pet
-      operationId: findPetById
-      produces:
-        - application/json
-        - application/xml
-        - text/xml
-        - text/html
-      parameters:
-        - name: id
-          in: path
-          description: ID of pet to fetch
-          required: true
-          type: integer
-          format: int64
-      responses:
-        '200':
-          description: pet response
-          schema:
-            $ref: '#/definitions/pet'
-        default:
-          description: unexpected error
-          schema:
-            $ref: '#/definitions/errorModel'
-    delete:
-      description: deletes a single pet based on the ID supplied
-      operationId: deletePet
-      parameters:
-        - name: id
-          in: path
-          description: ID of pet to delete
-          required: true
-          type: integer
-          format: int64
-      responses:
-        '204':
-          description: pet deleted
-        default:
-          description: unexpected error
-          schema:
-            $ref: '#/definitions/errorModel'
-definitions:
-  pet:
-    required:
-      - id
-      - name
-    properties:
-      id:
-        type: integer
-        format: int64
-      name:
-        type: string
-      tag:
-        type: string
-  newPet:
-    allOf:
-      - $ref: '#/definitions/pet'
-      - required:
-          - name
-        properties:
-          id:
-            type: integer
-            format: int64
-          name:
-            type: string
-  errorModel:
-    required:
-      - code
-      - message
-    properties:
-      code:
-        type: integer
-        format: int32
-      message:
-        type: string
 `

--- a/yamlutils_iface.go
+++ b/yamlutils_iface.go
@@ -1,0 +1,41 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import (
+	"encoding/json"
+
+	"github.com/go-openapi/swag/yamlutils"
+)
+
+// YAMLToJSON converts YAML unmarshaled data into json compatible data
+//
+// Deprecated: use [yamlutils.YAMLToJSON] instead.
+func YAMLToJSON(data interface{}) (json.RawMessage, error) { return yamlutils.YAMLToJSON(data) }
+
+// BytesToYAMLDoc converts a byte slice into a YAML document
+//
+// Deprecated: use [yamlutils.BytesToYAMLDoc] instead.
+func BytesToYAMLDoc(data []byte) (interface{}, error) { return yamlutils.BytesToYAMLDoc(data) }
+
+// JSONMapSlice represents a JSON object, with the order of keys maintained
+//
+// Deprecated: use [yamlutils.JSONMapSlice] instead.
+type JSONMapSlice = yamlutils.JSONMapSlice
+
+// JSONMapItem represents a JSON object, with the order of keys maintained
+//
+// Deprecated: use [yamlutils.JSONMapItem] instead.
+type JSONMapItem = yamlutils.JSONMapItem

--- a/yamlutils_iface_test.go
+++ b/yamlutils_iface_test.go
@@ -1,0 +1,36 @@
+// Copyright 2015 go-swagger maintainers
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package swag
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestYAMLUtilsIface(t *testing.T) {
+	t.Run("deprecated functions should work", func(t *testing.T) {
+		t.Run("with YAML bytes to document and back as JSON", func(t *testing.T) {
+			const ydoc = "x:\n  a: one\n  b: two\n"
+			doc, err := BytesToYAMLDoc([]byte(ydoc))
+			require.NoError(t, err)
+
+			buf, err := YAMLToJSON(doc)
+			require.NoError(t, err)
+
+			require.JSONEq(t, `{"x":{"a":"one","b":"two"}}`, string(buf))
+		})
+	})
+}


### PR DESCRIPTION
Follow-up on refactoring the swag API as more granular packages, and deprecating the vast API currently exposed by swag.

All existing methods are maintained and work.

Existing configuration using global vars will continue to work at the "swag" level: sub-packages no longer expose global variables.

Smaller packages will help maintain this very diverse set of features.

This API separates:
* loading : file loading utilities
* jsonutils, yamlutils: JSON & YAML document conversions