### PR TITLE
chore(ci): setup monorepo  linting and fixed automerge

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -38,7 +38,7 @@ updates:
         patterns:
           - "github.com/stretchr/testify"
 
-      golang.org-dependencies:
+      golang-org-dependencies:
         patterns:
           - "golang.org/*"
 

--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -35,7 +35,7 @@ jobs:
           GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Auto-merge dependabot PRs for golang.org updates
-        if: contains(steps.metadata.outputs.dependency-group, 'golang.org-dependencies')
+        if: contains(steps.metadata.outputs.dependency-group, 'golang-org-dependencies')
         run: gh pr merge --auto --rebase "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}

--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -10,9 +10,60 @@ on:
   pull_request:
 
 jobs:
-  lint:
-    name: Lint
+  module-matrix:
+    name: Go module matrix
     runs-on: ubuntu-latest
+
+    outputs:
+      modules: ${{ steps.modules.outputs.modules }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Find go modules
+        id: modules
+        shell: bash
+        run: |
+          # This script finds all go modules declared in this repo and resolves to a relative path to each of those.
+          #
+          # NOTES:
+          #
+          # > * git bash on a windows runner should support GNU find. find flags should be supported by find on macos.
+          # > * We don't attempt any tricks with the go work command. Perhaps this will be the official way in future go releases.
+          # > * There is no simple way to get the expected result with go list, unless all submodules are dependencies of the
+          #     root module (which is not a requirement).
+          set -euxo pipefail
+
+          root="$(git rev-parse --show-toplevel)"
+          cd "${root}"
+
+          declare -i index=0
+          declare -a all_mods
+          printf "modules=[" >> "$GITHUB_OUTPUT"
+          while read module_location ; do
+            if [ $index -gt 0 ] ; then
+              printf "," >> "$GITHUB_OUTPUT"
+            fi
+            relative_location=${module_location#"$root"/}
+            module_dir=${relative_location%"/go.mod"}
+            base_dir="${module_dir#"./"}"
+            printf " \"${base_dir}\"" >> "$GITHUB_OUTPUT"
+            all_mods+=("${base_dir}")
+            ((index++)) || true
+          done < <(find . -name \*.mod | grep -v "\.git" | sort | uniq)
+          printf "]" >> "$GITHUB_OUTPUT"
+
+          echo "::notice title=Modules found::${all_mods[@]}"
+
+  module-lint:
+    name: Go module lint
+    runs-on: ubuntu-latest
+    needs: [ module-matrix ]
+
+    strategy:
+      matrix:
+        # all sub modules in this repo must be linted separately
+        module: ${{ fromJSON(needs.module-matrix.outputs.modules) }}
+
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
@@ -26,15 +77,27 @@ jobs:
           version: latest
           only-new-issues: true
           skip-cache: true
+          working-directory: '${{ matrix.module }}'
 
-  test:
+  lint:
+    needs: [ module-lint ]
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Linting complete
+        run: |
+          echo "All modules linted"
+
+  module-test:
     name: Unit tests
     runs-on: ${{ matrix.os }}
+    needs: [ module-matrix ]
 
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest, windows-latest ]
         go_version: ['oldstable', 'stable' ]
+        module: ${{ fromJSON(needs.module-matrix.outputs.modules) }}
 
     steps:
     - uses: actions/setup-go@v5
@@ -44,24 +107,14 @@ jobs:
         cache: true
 
     - uses: actions/checkout@v4
-    - name: Run unit tests on all modules in this repo
+    - name: Run unit tests on a single module in this repo
       shell: bash
+      working-directory: '${{ matrix.module }}'
+      env:
+        # *.coverage.* pattern is automatically detected by codecov
+        COVER_PROFILE: "${{ matrix.module }}.coverage.${{ matrix.os }}.${{ matrix.go_version }}.out"
       run: |
-        # This script runs all tests on all modules and their subpackages.
-        #
-        # NOTES:
-        # * git bash on a windows runner should support GNU find. find flags should be supported by find on macos.
-        # * we don't attempt tricks using go work. Perhaps this will be the official way in future go releases.
-        set -euxo pipefail
-
-        find . -name \*.mod -execdir pwd \; | grep -v "\.git" | sort | uniq | \
-          while read module_dir ; do
-            pushd "${module_dir}"
-            # *.coverage.* pattern is automatically detected by codecov
-            coverprofile="${module_dir##*/}.coverage.${{ matrix.os }}.${{ matrix.go_version }}.out"
-            go test -v -race -coverprofile="${coverprofile}" -covermode=atomic -coverpkg=$(go list)/... ./...
-            popd
-          done
+        go test -v -race -coverprofile="${COVER_PROFILE}" -covermode=atomic -coverpkg=$(go list)/... ./...
 
     - name: Upload coverage to codecov
       uses: codecov/codecov-action@v5
@@ -70,3 +123,12 @@ jobs:
         flags: '${{ matrix.go_version }}-${{ matrix.os }}'
         fail_ci_if_error: false
         verbose: true
+
+  test:
+    needs: [ module-test ]
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Tests complete
+        run: |
+          echo "All tests completed"

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -17,12 +17,14 @@ linters:
     - gomoddirectives
     - gosmopolitan
     - inamedparam
+    - intrange # disabled while < go1.22
     - ireturn
     - lll
     - musttag
     - nestif
     - nlreturn
     - nonamedreturns
+    - noinlineerr
     - paralleltest
     - recvcheck
     - testpackage
@@ -33,6 +35,7 @@ linters:
     - whitespace
     - wrapcheck
     - wsl
+    - wsl_v5
   settings:
     dupl:
       threshold: 200
@@ -62,3 +65,12 @@ formatters:
       - third_party$
       - builtin$
       - examples$
+issues:
+  # Maximum issues count per one linter.
+  # Set to 0 to disable.
+  # Default: 50
+  max-issues-per-linter: 0
+  # Maximum count of issues with the same text.
+  # Set to 0 to disable.
+  # Default: 3
+  max-same-issues: 0

--- a/fileutils/path_test.go
+++ b/fileutils/path_test.go
@@ -26,11 +26,9 @@ import (
 )
 
 func makeDirStructure(tb testing.TB, tgt string) (string, string) {
-	tb.Helper()
+	_ = tgt
 
-	if tgt == "" {
-		tgt = "pkgpaths"
-	}
+	tb.Helper()
 
 	td := tb.TempDir()
 	realPath := filepath.Join(td, "src", "foo", "bar")

--- a/hack/tag_modules.sh
+++ b/hack/tag_modules.sh
@@ -17,8 +17,9 @@ cd "${root}"
 echo "Tagging all modules in repo ${root##*/}..."
 
 while read module_location ; do
-  module_dir=${module_location%/*}
-  base_tag="${module_dir#*/}"
+  relative_location=${module_location#"$root"/}
+  module_dir=${relative_location%"/go.mod"}
+  base_tag="${module_dir#"./"}"
   if [[ "${base_tag}" ==  "." ]] ; then
     module_tag="${tag}" # e.g. "v0.24.0"
   else

--- a/jsonname/name_provider.go
+++ b/jsonname/name_provider.go
@@ -124,12 +124,6 @@ func (n *NameProvider) GetJSONNameForType(tpe reflect.Type, name string) (string
 	return nme, ok
 }
 
-func (n *NameProvider) makeNameIndex(tpe reflect.Type) nameIndex {
-	names := newNameIndex(tpe)
-	n.index[tpe] = names
-	return names
-}
-
 // GetGoName gets the go name for a json property name
 func (n *NameProvider) GetGoName(subject interface{}, name string) (string, bool) {
 	tpe := reflect.Indirect(reflect.ValueOf(subject)).Type()
@@ -146,4 +140,10 @@ func (n *NameProvider) GetGoNameForType(tpe reflect.Type, name string) (string, 
 	}
 	nme, ok := names.jsonNames[name]
 	return nme, ok
+}
+
+func (n *NameProvider) makeNameIndex(tpe reflect.Type) nameIndex {
+	names := newNameIndex(tpe)
+	n.index[tpe] = names
+	return names
 }

--- a/jsonutils/json_test.go
+++ b/jsonutils/json_test.go
@@ -29,6 +29,7 @@ type SharedCounters struct {
 
 type AggregationObject struct {
 	SharedCounters
+
 	Count int64 `json:"count,omitempty"`
 }
 

--- a/jsonutils/ordered_map.go
+++ b/jsonutils/ordered_map.go
@@ -138,10 +138,10 @@ func (s *JSONMapItem) asInterface(in *jlexer.Lexer) any {
 		if strings.ContainsRune(n, '.') {
 			f, _ := strconv.ParseFloat(n, 64)
 			return f
-		} else {
-			i, _ := strconv.ParseInt(n, 10, 64)
-			return i
 		}
+
+		i, _ := strconv.ParseInt(n, 10, 64)
+		return i
 
 	case jlexer.TokenBool:
 		return in.Bool()

--- a/mangling/initialism_index.go
+++ b/mangling/initialism_index.go
@@ -115,8 +115,9 @@ func DefaultInitialisms() []string {
 }
 
 type indexOfInitialisms struct {
-	index map[string]struct{}
 	initialismsCache
+
+	index map[string]struct{}
 }
 
 func newIndexOfInitialisms() *indexOfInitialisms {

--- a/mangling/name_mangler.go
+++ b/mangling/name_mangler.go
@@ -80,11 +80,6 @@ func NewNameMangler(opts ...Option) NameMangler {
 	return m
 }
 
-func (m *NameMangler) addInitialisms(words ...string) {
-	m.index.add(words...)
-	m.index.buildCache()
-}
-
 // AddInitialisms declares extra initialisms to the mangler.
 //
 // It declares extra words as "initialisms" (i.e. words that won't be camel cased or titled cased),
@@ -106,20 +101,6 @@ func (m *NameMangler) AddInitialisms(words ...string) {
 // Initialisms renders the list of initialisms supported by this mangler.
 func (m *NameMangler) Initialisms() []string {
 	return m.index.initialisms
-}
-
-// split calls the inner splitter.
-func (m NameMangler) split(str string) *[]string {
-	s := m.splitter
-	lexems := s.split(str)
-	result := poolOfStrings.BorrowStrings()
-
-	for _, lexem := range *lexems {
-		*result = append(*result, lexem.GetOriginal())
-	}
-	poolOfLexems.RedeemLexems(lexems)
-
-	return result
 }
 
 // Camelize a single word.
@@ -378,4 +359,23 @@ func (m NameMangler) goIdentifier(name string, exported bool) string {
 	}
 
 	return result.String()
+}
+
+func (m *NameMangler) addInitialisms(words ...string) {
+	m.index.add(words...)
+	m.index.buildCache()
+}
+
+// split calls the inner splitter.
+func (m NameMangler) split(str string) *[]string {
+	s := m.splitter
+	lexems := s.split(str)
+	result := poolOfStrings.BorrowStrings()
+
+	for _, lexem := range *lexems {
+		*result = append(*result, lexem.GetOriginal())
+	}
+	poolOfLexems.RedeemLexems(lexems)
+
+	return result
 }

--- a/mangling/split.go
+++ b/mangling/split.go
@@ -53,6 +53,7 @@ func (m initialismMatch) isZero() bool {
 
 type splitter struct {
 	*initialismsCache
+
 	postSplitInitialismCheck bool
 	replaceFunc              ReplaceFunc
 }

--- a/yamlutils/ordered_map.go
+++ b/yamlutils/ordered_map.go
@@ -12,7 +12,7 @@ import (
 
 var (
 	_ yaml.Marshaler = YAMLMapSlice{}
-	//_ yaml.Unmarshaler = &YAMLMapSlice{} // TODO: implement yaml.Unmarshaler
+	// _ yaml.Unmarshaler = &YAMLMapSlice{} // TODO: implement yaml.Unmarshaler
 )
 
 // YAMLMapSlice represents a YAML object, with the order of keys maintained.

--- a/yamlutils/yaml_test.go
+++ b/yamlutils/yaml_test.go
@@ -292,13 +292,13 @@ name: a string value
 }
 
 func TestWithYKey(t *testing.T) {
-	doc, err := BytesToYAMLDoc([]byte(fixtureWithYKey))
+	doc, err := BytesToYAMLDoc(fixtureWithYKey)
 	require.NoError(t, err)
 
 	_, err = YAMLToJSON(doc)
 	require.NoError(t, err)
 
-	doc, err = BytesToYAMLDoc([]byte(fixtureWithQuotedYKey))
+	doc, err = BytesToYAMLDoc(fixtureWithQuotedYKey)
 	require.NoError(t, err)
 	jsond, err := YAMLToJSON(doc)
 	require.NoError(t, err)


### PR DESCRIPTION
* golangci-lint no longer digs into sub-modules: we have to run the action explicitly with "working-directory"

* setup a matrix of submodules to lint all modules in this repo

* auto-merge: the issue with golang.org updates auto-merge rule is caused by the name of the group "golang.org-dependencies" is internally rewritten as a slug name "golang-org-dependencies" (with a dash, not a dot) so this no longer matches the triggering rules.

* fixed the group name to replace "." by "-"