### PR TITLE
doc: add portable agentic instructions

### DIFF
--- a/.claude/.gitignore
+++ b/.claude/.gitignore
@@ -1,0 +1,5 @@
+plans/
+skills/
+commands/
+agents/
+hooks/

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,91 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+Go monorepo of utility libraries for the `go-openapi` / `go-swagger` ecosystem. The root package
+is a **backward-compat facade** — all its exported functions are deprecated and delegate to sub-packages.
+
+See [docs/MAINTAINERS.md](../docs/MAINTAINERS.md) for CI/CD, release process, and repo structure details.
+
+## Workspace & Modules
+
+Go workspace (`go.work`, Go 1.24). Contains 15+ modules:
+
+| Module | Purpose |
+|--------|---------|
+| `.` (root) | Deprecated shims forwarding to sub-packages |
+| `cmdutils` | CLI utility helpers |
+| `conv` | Type conversions: string-to-value, value-to-pointer, pointer-to-value (generics) |
+| `fileutils` | File and path utilities |
+| `jsonname` | Infer JSON field names from Go struct tags |
+| `jsonutils` | JSON read/write, `ConcatJSON`, `JSONMapSlice`; pluggable adapter system |
+| `jsonutils/adapters/easyjson` | easyjson adapter (separate module to isolate dependency) |
+| `loading` | Load specs from filesystem or HTTP |
+| `mangling` | Name mangling: `ToGoName`, `ToFileName`, `ToVarName`, etc.; configurable initialisms |
+| `netutils` | Host/port parsing |
+| `stringutils` | Slice search, query parameter splitting |
+| `typeutils` | Zero-value and nil-safe interface checks |
+| `yamlutils` | YAML-to-JSON conversion, ordered YAML documents |
+
+Inter-module dependencies use `replace` directives pointing to local paths.
+
+## Testing
+
+```sh
+# Run all tests across every workspace module
+go test work ./...
+
+# Run tests for a single module
+go test ./conv/...
+```
+
+Note: plain `go test ./...` only tests the root module. The `work` pattern expands to all
+modules listed in `go.work`.
+
+CI runs tests on `{ubuntu, macos, windows} x {stable, oldstable}` with `-race` via `gotestsum`.
+
+### Fuzz tests
+
+```sh
+# List all fuzz targets across the workspace
+go test work -list Fuzz ./...
+
+# Run a specific fuzz target (go test -fuzz cannot span multiple packages)
+go test -fuzz=Fuzz -run='FuzzToGoName$' -fuzztime=1m30s ./mangling
+```
+
+Fuzz corpus lives in `testdata/fuzz/` within each package. CI runs each fuzz target for 1m30s
+with a 5m minimize timeout.
+
+### Test framework
+
+`github.com/go-openapi/testify/v2` — a zero-dep fork of `stretchr/testify`.
+Because it's a fork, `testifylint` does not work.
+
+Patterns: table-driven tests with `t.Run`, fuzz tests, benchmarks, and integration
+tests in `jsonutils/adapters/testintegration/`.
+
+## Linting
+
+```sh
+golangci-lint run
+```
+
+Config: `.golangci.yml` — posture is `default: all` with explicit disables.
+See [docs/STYLE.md](../docs/STYLE.md) for the rationale behind each disabled linter.
+
+Key rules:
+- Every `//nolint` directive **must** have an inline comment explaining why.
+- Prefer disabling a linter over scattering `//nolint` across the codebase.
+
+## Code Conventions
+
+- All files must have SPDX license headers (Apache-2.0).
+- Go version policy: support the 2 latest stable Go minor versions.
+- Commits require DCO sign-off (`git commit -s`).
+- Root-level `*_iface.go` files are thin deprecated wrappers — do not add new public API there.
+- `jsonutils` uses a pluggable adapter registry (`adapters.Registry`); new JSON backends
+  should be separate modules implementing interfaces from `jsonutils/adapters/ifaces`.
+- `mangling.NameMangler` is configured via functional options and is concurrency-safe.

--- a/.claude/rules/contributions.md
+++ b/.claude/rules/contributions.md
@@ -1,0 +1,52 @@
+---
+paths:
+  - "**/*"
+---
+
+# Contribution rules (go-openapi)
+
+Read `.github/CONTRIBUTING.md` before opening a pull request.
+
+## Commit hygiene
+
+- Every commit **must** be DCO signed-off (`git commit -s`) with a real email address.
+  PGP-signed commits are appreciated but not required.
+- Agents may be listed as co-authors (`Co-Authored-By:`) but the commit **author must be the human sponsor**.
+  We do not accept commits solely authored by bots or agents.
+- Squash commits into logical units of work before requesting review (`git rebase -i`).
+
+## Linting
+
+Before pushing, verify your changes pass linting against the base branch:
+
+```sh
+golangci-lint run --new-from-rev master
+```
+
+Install the latest version if you don't have it:
+
+```sh
+go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest
+```
+
+## Problem statement
+
+- Clearly describe the problem the PR solves, or reference an existing issue.
+- PR descriptions must not be vague ("fix bug", "improve code") — explain *what* was wrong and *why* the change is correct.
+
+## Tests are mandatory
+
+- Every bug fix or feature **must** include tests that demonstrate the problem and verify the fix.
+- The only exceptions are documentation changes and typo fixes.
+- Aim for at least 80% coverage of your patch.
+- Run the full test suite before submitting:
+
+For mono-repos:
+```sh
+go test work ./...
+```
+
+For single module repos:
+```sh
+go test ./...
+```

--- a/.claude/rules/github-workflows-conventions.md
+++ b/.claude/rules/github-workflows-conventions.md
@@ -1,0 +1,297 @@
+---
+paths:
+  - ".github/workflows/**.yml"
+  - ".github/workflows/**.yaml"
+---
+
+# GitHub Actions Workflows Formatting and Style Conventions
+
+This rule captures YAML and bash formatting rules to provide a consistent maintainer's experience across CI workflows.
+
+## File Structure
+
+**REQUIRED**:  All github action workflows are organized as a flat structure beneath `.github/workflows/`.
+
+> GitHub does not support a hierarchical organization for workflows yet.
+
+**REQUIRED**:  YAML files are conventionally named `{workflow}.yml`, with the `.yml` extension.
+
+## Code Style & Formatting
+
+### Expression Spacing
+
+**REQUIRED**: All GitHub Actions expressions must have spaces inside the braces:
+
+```yaml
+# ✅ CORRECT
+env:
+  PR_URL: ${{ github.event.pull_request.html_url }}
+  TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+# ❌ WRONG
+env:
+  PR_URL: ${{github.event.pull_request.html_url}}
+  TOKEN: ${{secrets.GITHUB_TOKEN}}
+```
+
+> Provides a consistent formatting rule.
+
+### Conditional Syntax
+
+**REQUIRED**: Always use `${{ }}` in `if:` conditions:
+
+```yaml
+# ✅ CORRECT
+if: ${{ inputs.enable-signing == 'true' }}
+if: ${{ github.event.pull_request.user.login == 'dependabot[bot]' }}
+
+# ❌ WRONG (works but inconsistent)
+if: inputs.enable-signing == 'true'
+```
+
+> Provides a consistent formatting rule.
+
+### GitHub Workflow Commands
+
+**REQUIRED**: Use workflow commands for status messages that should appear as annotations, with **double colon separator**:
+
+```bash
+# ✅ CORRECT - Double colon (::) separator after title
+echo "::notice title=build::Build completed successfully"
+echo "::warning title=race-condition::Merge already in progress"
+echo "::error title=deployment::Failed to deploy"
+
+# ❌ WRONG - Single colon separator (won't render as annotation)
+echo "::notice title=build:Build completed"  # Missing second ':'
+echo "::warning title=x:message"             # Won't display correctly
+```
+
+**Syntax pattern:** `::LEVEL title=TITLE::MESSAGE`
+- `LEVEL`: notice, warning, or error
+- Double `::` separator is required between title and message
+
+> Wrong syntax may raise untidy warnings and produce botched output.
+
+### YAML arrays formatting
+
+For steps, YAML arrays are formatted with the following indentation:
+
+```yaml
+# ✅ CORRECT - Clear spacing between steps
+    steps:
+      -
+        name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+      -
+        name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+# ❌ WRONG - Dense format, more difficult to read
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+
+# ❌ WRONG - YAML comment or blank line could be avoided
+    steps:
+      #
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+```
+
+## Security Best Practices
+
+### Version Pinning using SHAs
+
+**REQUIRED**: Always pin action versions to commit SHAs:
+
+> Runs must be repeatable with known pinned version. Automated updates are pushed frequently (e.g. daily or weekly)
+> to keep pinned versions up-to-date.
+
+```yaml
+# ✅ CORRECT - Pinned to commit SHA with version comment
+uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
+uses: crazy-max/ghaction-import-gpg@e89d40939c28e39f97cf32126055eeae86ba74ec # v6.3.0
+
+# ❌ WRONG - Mutable tag reference
+uses: actions/checkout@v6
+```
+
+### Permission settings
+
+**REQUIRED**: Always set minimal permissions at the workflow level.
+
+```yaml
+# ✅ CORRECT - Workflow level permissions set to minimum
+permissions:
+  contents: read
+
+# ❌ WRONG - Workflow level permissions with undue privilege escalation
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+**REQUIRED**: Whenever a job needs elevated privileges, always raise required permissions at the job level.
+
+```yaml
+# ✅ CORRECT - Job level permissions set to the specific requirements for that job
+jobs:
+  dependabot:
+    permissions:
+      contents: write
+      pull-requests: write
+    uses: ./.github/workflows/auto-merge.yml
+    secrets: inherit
+
+# ❌ WRONG - Same permissions but set at workflow level instead of job level
+permissions:
+  contents: write
+  pull-requests: write
+```
+
+> (Security best practice detected by CodeQL analysis)
+
+### Undue secret exposure
+
+**NEVER** use `secrets[inputs.name]` — always use explicit secret parameters.
+
+> Using keyed access to secrets forces the runner to expose ALL secrets to the job, which causes a security risk
+> (caught and reported by CodeQL security analysis).
+
+```yaml
+# ❌ SECURITY VULNERABILITY
+# This exposes ALL organization and repository secrets to the runner
+on:
+  workflow_call:
+    inputs:
+      secret-name:
+        type: string
+jobs:
+  my-job:
+    steps:
+      - uses: some-action@v1
+        with:
+          token: ${{ secrets[inputs.secret-name] }}  # ❌ DANGEROUS!
+```
+
+**SOLUTION**: Use explicit secret parameters with fallback for defaults:
+
+```yaml
+# ✅ SECURE
+on:
+  workflow_call:
+    secrets:
+      gpg-private-key:
+        required: false
+jobs:
+  my-job:
+    steps:
+      - uses: go-openapi/gh-actions/ci-jobs/bot-credentials@master
+        with:
+          # Falls back to go-openapi default if not explicitly passed
+          gpg-private-key: ${{ secrets.gpg-private-key || secrets.CI_BOT_GPG_PRIVATE_KEY }}
+```
+
+## Common Gotchas
+
+### Description fields containing parsable expressions
+
+**REQUIRED**: **DO NOT** use `${{ }}` expressions in description fields:
+
+> They may be parsed by the runner, wrongly interpreted or causing failure (e.g. "not defined in this context").
+
+```yaml
+# ❌ WRONG - Can cause YAML parsing errors
+description: |
+  Pass it as: gpg-private-key: ${{ secrets.MY_KEY }}
+
+# ✅ CORRECT
+description: |
+  Pass it as: secrets.MY_KEY
+```
+
+### Boolean inputs
+
+**Boolean inputs are forbidden**: NEVER use `type: boolean` for workflow inputs due to unpredictable type coercion
+
+> gh-action expressions using boolean job inputs are hard to predict and come with many quirks.
+
+   ```yaml
+   # ❌ FORBIDDEN - Boolean inputs have type coercion issues
+   on:
+     workflow_call:
+       inputs:
+         enable-feature:
+           type: boolean        # ❌ NEVER USE THIS
+           default: true
+
+   # The pattern `x == 'true' || x == true` seems safe but fails when:
+   # - x is not a boolean: `x == true` evaluates to true if x != null
+   # - Type coercion is unpredictable and error-prone
+
+   # ✅ CORRECT - Always use string type for boolean-like inputs
+   on:
+     workflow_call:
+       inputs:
+         enable-feature:
+           type: string         # ✅ Use string instead
+           default: 'true'      # String value
+
+   jobs:
+     my-job:
+       # Simple, reliable comparison
+       if: ${{ inputs.enable-feature == 'true' }}
+
+   # ✅ In bash, this works perfectly (inputs are always strings in bash):
+   if [[ '${{ inputs.enable-feature }}' == 'true' ]]; then
+     echo "Feature enabled"
+   fi
+   ```
+
+   **Rule**: Use `type: string` with values `'true'` or `'false'` for all boolean-like workflow inputs.
+
+   **Note**: Step outputs and bash variables are always strings, so `x == 'true'` works fine for those.
+
+### YAML fold scalars in action inputs
+
+**NEVER** use `>` or `>-` (fold scalars) for `with:` input values:
+
+> The YAML spec says fold scalars replace newlines with spaces, but the GitHub Actions runner
+> does not reliably honor this for action inputs. The action receives the literal multi-line string
+> instead of a single folded line, which breaks flag parsing.
+
+```yaml
+# ❌ BROKEN - Fold scalar, args received with embedded newlines
+- uses: goreleaser/goreleaser-action@...
+  with:
+    args: >-
+      release
+        --clean
+        --release-notes /tmp/notes.md
+
+# ✅ CORRECT - Single line
+- uses: goreleaser/goreleaser-action@...
+  with:
+    args: release --clean --release-notes /tmp/notes.md
+
+# ✅ CORRECT - Literal block scalar (|) is fine for run: scripts
+- run: |
+    echo "line 1"
+    echo "line 2"
+```
+
+**Rule**: Use single-line strings for `with:` inputs. Only use `|` (literal block scalar) for `run:` scripts where multi-line is intentional.

--- a/.claude/rules/go-conventions.md
+++ b/.claude/rules/go-conventions.md
@@ -1,0 +1,11 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Code conventions (go-openapi)
+
+- All files must have SPDX license headers (Apache-2.0).
+- Go version policy: support the 2 latest stable Go minor versions.
+- Commits require DCO sign-off (`git commit -s`).
+- use `golangci-lint fmt` to format code (not `gofmt` or `gofumpt`)

--- a/.claude/rules/linting.md
+++ b/.claude/rules/linting.md
@@ -1,0 +1,17 @@
+---
+paths:
+  - "**/*.go"
+---
+
+# Linting conventions (go-openapi)
+
+```sh
+golangci-lint run
+```
+
+Config: `.golangci.yml` — posture is `default: all` with explicit disables.
+See `docs/STYLE.md` for the rationale behind each disabled linter.
+
+Key rules:
+- Every `//nolint` directive **must** have an inline comment explaining why.
+- Prefer disabling a linter over scattering `//nolint` across the codebase.

--- a/.claude/rules/testing.md
+++ b/.claude/rules/testing.md
@@ -1,0 +1,47 @@
+---
+paths:
+  - "**/*_test.go"
+---
+
+# Testing conventions (go-openapi)
+
+## Running tests
+
+**Single module repos:**
+
+```sh
+go test ./...
+```
+
+**Mono-repos (with `go.work`):**
+
+```sh
+# All modules
+go test work ./...
+
+# Single module
+go test ./conv/...
+```
+
+Note: in mono-repos, plain `go test ./...` only tests the root module.
+The `work` pattern expands to all modules listed in `go.work`.
+
+CI runs tests on `{ubuntu, macos, windows} x {stable, oldstable}` with `-race` via `gotestsum`.
+
+## Fuzz tests
+
+```sh
+# List all fuzz targets
+go test -list Fuzz ./...
+
+# Run a specific target (go test -fuzz cannot span multiple packages)
+go test -fuzz=Fuzz -run='FuzzTargetName$' -fuzztime=1m30s ./package
+```
+
+Fuzz corpus lives in `testdata/fuzz/` within each package. CI runs each fuzz target for 1m30s
+with a 5m minimize timeout.
+
+## Test framework
+
+`github.com/go-openapi/testify/v2` — a zero-dep fork of `stretchr/testify`.
+Because it's a fork, `testifylint` does not work.

--- a/.github/copilot
+++ b/.github/copilot
@@ -1,0 +1,1 @@
+../.claude/rules

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,0 +1,34 @@
+# Copilot Instructions
+
+## Project Overview
+
+Go mono-repo of utility libraries for the `go-openapi` / `go-swagger` ecosystem.
+The root package is a backward-compatible facade — all its exported functions are
+deprecated and delegate to sub-packages. New code belongs in the appropriate
+sub-package, not the root.
+
+The repo exists to give the go-swagger code generator and runtime a single,
+well-tested set of helpers for name mangling, type conversions, JSON/YAML
+handling, file loading, and other common tasks, without pulling in heavy
+external dependencies.
+
+## Workspace & Modules
+
+Go workspace (`go.work`, Go 1.24) with 15+ modules including:
+`conv`, `cmdutils`, `fileutils`, `jsonname`, `jsonutils`, `loading`,
+`mangling`, `netutils`, `stringutils`, `typeutils`, `yamlutils`, and others.
+
+## Conventions
+
+Coding conventions are found beneath `.github/copilot`
+
+### Summary
+
+- All `.go` files must have SPDX license headers (Apache-2.0).
+- Commits require DCO sign-off (`git commit -s`).
+- Linting: `golangci-lint run` — config in `.golangci.yml` (posture: `default: all` with explicit disables).
+- Every `//nolint` directive **must** have an inline comment explaining why.
+- Tests: `go test work ./...` (mono-repo). CI runs on `{ubuntu, macos, windows} x {stable, oldstable}` with `-race`.
+- Test framework: `github.com/go-openapi/testify/v2` (not `stretchr/testify`; `testifylint` does not work).
+
+See `.github/copilot/` (symlinked to `.claude/rules/`) for detailed rules on Go conventions, linting, testing, and contributions.

--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,3 @@ Godeps
 .idea
 *.out
 .mcp.json
-.claude/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,1 @@
+.github/copilot-instructions.md


### PR DESCRIPTION
## Summary

- Add `AGENTS.md` (symlink) for cross-tool AI agent support
- Add `.github/copilot-instructions.md` and `.github/copilot` symlink
- Add `.claude/.gitignore` to keep local-only files out of version control
- Add `contributions.md` and `github-workflows-conventions.md` rules
- Track previously ignored `CLAUDE.md`, `linting.md` and `testing.md`
- Fix `.gitignore` to stop ignoring `.claude/` directory

## Test plan

- [ ] Verify symlinks resolve correctly
- [ ] Confirm no functional code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)