### PR TITLE
chore: bump go directive to 1.25.0

### DIFF
--- a/cmdutils/go.mod
+++ b/cmdutils/go.mod
@@ -1,3 +1,3 @@
 module github.com/go-openapi/swag/cmdutils
 
-go 1.24.0
+go 1.25.0

--- a/conv/go.mod
+++ b/conv/go.mod
@@ -7,4 +7,4 @@ require (
 
 replace github.com/go-openapi/swag/typeutils => ../typeutils
 
-go 1.24.0
+go 1.25.0

--- a/fileutils/go.mod
+++ b/fileutils/go.mod
@@ -2,4 +2,4 @@ module github.com/go-openapi/swag/fileutils
 
 require github.com/go-openapi/testify/v2 v2.4.1
 
-go 1.24.0
+go 1.25.0

--- a/go.mod
+++ b/go.mod
@@ -34,4 +34,4 @@ replace (
 	github.com/go-openapi/swag/yamlutils => ./yamlutils
 )
 
-go 1.24.0
+go 1.25.0

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/go-openapi/testify/enable/yaml/v2 v2.4.0 h1:7SgOMTvJkM8yWrQlU8Jm18VeDPuAvB/xWrdxFJkoFag=
-github.com/go-openapi/testify/enable/yaml/v2 v2.4.0/go.mod h1:14iV8jyyQlinc9StD7w1xVPW3CO3q1Gj04Jy//Kw4VM=
+github.com/go-openapi/testify/enable/yaml/v2 v2.4.1 h1:NZOrZmIb6PTv5LTFxr5/mKV/FjbUzGE7E6gLz7vFoOQ=
+github.com/go-openapi/testify/enable/yaml/v2 v2.4.1/go.mod h1:r7dwsujEHawapMsxA69i+XMGZrQ5tRauhLAjV/sxg3Q=
 github.com/go-openapi/testify/v2 v2.4.1 h1:zB34HDKj4tHwyUQHrUkpV0Q0iXQ6dUCOQtIqn8hE6Iw=
 github.com/go-openapi/testify/v2 v2.4.1/go.mod h1:HCPmvFFnheKK2BuwSA0TbbdxJ3I16pjwMkYkP4Ywn54=
 go.yaml.in/yaml/v3 v3.0.4 h1:tfq32ie2Jv2UxXFdLJdh3jXuOzWiL1fo0bu/FbuKpbc=

--- a/go.work
+++ b/go.work
@@ -17,4 +17,4 @@ use (
 	./yamlutils
 )
 
-go 1.24.0
+go 1.25.0

--- a/jsonname/go.mod
+++ b/jsonname/go.mod
@@ -2,4 +2,4 @@ module github.com/go-openapi/swag/jsonname
 
 require github.com/go-openapi/testify/v2 v2.4.1
 
-go 1.24.0
+go 1.25.0

--- a/jsonutils/adapters/easyjson/go.mod
+++ b/jsonutils/adapters/easyjson/go.mod
@@ -22,4 +22,4 @@ replace (
 	github.com/go-openapi/swag/typeutils => ../../../typeutils
 )
 
-go 1.24.0
+go 1.25.0

--- a/jsonutils/adapters/testintegration/benchmarks/go.mod
+++ b/jsonutils/adapters/testintegration/benchmarks/go.mod
@@ -24,4 +24,4 @@ replace (
 	github.com/go-openapi/swag/typeutils => ../../../../typeutils
 )
 
-go 1.24.0
+go 1.25.0

--- a/jsonutils/adapters/testintegration/go.mod
+++ b/jsonutils/adapters/testintegration/go.mod
@@ -24,4 +24,4 @@ replace (
 	github.com/go-openapi/swag/typeutils => ../../../typeutils
 )
 
-go 1.24.0
+go 1.25.0

--- a/jsonutils/fixtures_test/go.mod
+++ b/jsonutils/fixtures_test/go.mod
@@ -6,4 +6,4 @@ require (
 	go.yaml.in/yaml/v3 v3.0.4
 )
 
-go 1.24.0
+go 1.25.0

--- a/jsonutils/go.mod
+++ b/jsonutils/go.mod
@@ -18,4 +18,4 @@ replace (
 	github.com/go-openapi/swag/typeutils => ../typeutils
 )
 
-go 1.24.0
+go 1.25.0

--- a/loading/go.mod
+++ b/loading/go.mod
@@ -21,4 +21,4 @@ replace (
 	github.com/go-openapi/swag/yamlutils => ../yamlutils
 )
 
-go 1.24.0
+go 1.25.0

--- a/mangling/go.mod
+++ b/mangling/go.mod
@@ -2,4 +2,4 @@ module github.com/go-openapi/swag/mangling
 
 require github.com/go-openapi/testify/v2 v2.4.1
 
-go 1.24.0
+go 1.25.0

--- a/netutils/go.mod
+++ b/netutils/go.mod
@@ -2,4 +2,4 @@ module github.com/go-openapi/swag/netutils
 
 require github.com/go-openapi/testify/v2 v2.4.1
 
-go 1.24.0
+go 1.25.0

--- a/stringutils/go.mod
+++ b/stringutils/go.mod
@@ -2,4 +2,4 @@ module github.com/go-openapi/swag/stringutils
 
 require github.com/go-openapi/testify/v2 v2.4.1
 
-go 1.24.0
+go 1.25.0

--- a/typeutils/go.mod
+++ b/typeutils/go.mod
@@ -2,4 +2,4 @@ module github.com/go-openapi/swag/typeutils
 
 require github.com/go-openapi/testify/v2 v2.4.1
 
-go 1.24.0
+go 1.25.0

--- a/yamlutils/go.mod
+++ b/yamlutils/go.mod
@@ -17,4 +17,4 @@ replace (
 	github.com/go-openapi/swag/typeutils => ../typeutils
 )
 
-go 1.24.0
+go 1.25.0


### PR DESCRIPTION
## Summary

- Update all `go.mod` (and `go.work` where applicable) to require `go 1.25.0`
- Run `go mod tidy` / `go work sync` to update checksums

## Test plan

- [ ] CI passes on all platforms (ubuntu, macos, windows) x (stable, oldstable)

🤖 Generated with [Claude Code](https://claude.com/claude-code)