### PR TITLE
doc(loading): document security implications of using the loader

### DIFF
--- a/loading/doc.go
+++ b/loading/doc.go
@@ -15,11 +15,15 @@
 // and is therefore safer than passing an [os.DirFS] to [WithFS], which does not block
 // symlink escapes.
 //
-// Remote loading uses a standard [net/http] client. By default it follows redirects and
-// performs no destination filtering — exactly like [net/http.DefaultClient]. A
-// caller-controlled URL may therefore reach internal services or cloud metadata endpoints
-// (server-side request forgery). This package does not, and should not, embed a network
-// policy: when the URL may derive from untrusted input, supply a restricted client with
+// Remote loading uses a standard [net/http] client.
+// By default it follows redirects and performs no destination filtering — exactly like [net/http.DefaultClient].
+//
+// A caller-controlled URL may therefore reach internal services or cloud metadata endpoints
+// (server-side request forgery).
+//
+// This package does not, and should not, embed a network policy:
+// when the URL may derive from untrusted input, supply a restricted client with
 // [WithHTTPClient] whose transport rejects unwanted destinations at dial time — which also
-// covers redirects and DNS rebinding. See the example on [LoadFromFileOrHTTP].
+// covers redirects and DNS rebinding.
+// See the example on [LoadFromFileOrHTTP].
 package loading


### PR DESCRIPTION
Expose security implications of the loader depending on the load strategy being selected.

Details available options to apply more restrictive policies on remote URLs or local file system access whenever needed.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
