### PR TITLE
fix(loading): resolve absolute in-root paths under WithRoot

### DIFF
--- a/loading/loading.go
+++ b/loading/loading.go
@@ -84,7 +84,9 @@ func LoadStrategy(pth string, local, remote func(string) ([]byte, error), opts .
 
 			if isFSBacked {
 				// other fs.FS (e.g. os.DirFS) and os.Root loaders also use "/" on every platform.
-				// Escaping paths (absolute, "..", escaping symlinks) are rejected by the loader, not rewritten here.
+				// Path confinement is enforced by the loader, not here: the os.Root loader rebases
+				// absolute in-root paths and rejects escaping paths ("..", out-of-root absolute,
+				// escaping symlinks); an fs.FS loader rejects what its file system does not allow.
 				return local(filepath.ToSlash(cpth))
 			}
 

--- a/loading/options.go
+++ b/loading/options.go
@@ -8,6 +8,7 @@ import (
 	"io/fs"
 	"net/http"
 	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -39,13 +40,21 @@ func (fo fileOptions) ReadFileFunc() func(string) ([]byte, error) {
 		root := fo.root
 
 		return func(name string) ([]byte, error) {
+			// os.Root only accepts paths relative to the root, but callers (and this package's
+			// own file:// handling) routinely produce absolute paths. Rebase an absolute path
+			// onto the root before handing it to os.Root.
+			rel, err := rootRelative(root, name)
+			if err != nil {
+				return nil, errors.Join(err, ErrLoader)
+			}
+
 			r, err := os.OpenRoot(root)
 			if err != nil {
 				return nil, errors.Join(err, ErrLoader)
 			}
 			defer func() { _ = r.Close() }()
 
-			return r.ReadFile(name)
+			return r.ReadFile(rel)
 		}
 	}
 
@@ -54,6 +63,30 @@ func (fo fileOptions) ReadFileFunc() func(string) ([]byte, error) {
 	}
 
 	return fo.fs.ReadFile
+}
+
+// rootRelative expresses name as a path relative to root, so that it can be resolved by os.Root.
+//
+// A relative name is returned unchanged: os.Root confines it directly (including "../" traversal
+// and symlink escapes, which it rejects at open time).
+//
+// An absolute name is rebased onto root. If it cannot be expressed relative to root — for
+// example because it lives on a different volume on Windows — filepath.Rel returns an error,
+// which is propagated so the read is rejected rather than silently escaping the root. An
+// absolute path that lexically escapes root yields a "../" prefix here and is then rejected by
+// os.Root.
+func rootRelative(root, name string) (string, error) {
+	osName := filepath.FromSlash(name)
+	if !filepath.IsAbs(osName) {
+		return name, nil
+	}
+
+	absRoot, err := filepath.Abs(filepath.FromSlash(root))
+	if err != nil {
+		return "", err
+	}
+
+	return filepath.Rel(absRoot, osName)
 }
 
 // WithTimeout sets a timeout for the remote file loader.
@@ -123,10 +156,12 @@ func WithFS(filesystem fs.FS) Option {
 
 // WithRoot confines local file loading to dir.
 //
-// Every requested path is resolved relative to dir, and any path that would escape dir —
-// whether through an absolute path, ".." traversal, or a symlink pointing outside dir — is
-// rejected. This is built on [os.Root] and is therefore resistant to the symlink escapes
-// that a plain [os.DirFS] does not prevent.
+// Every requested path is resolved within dir. A relative path is resolved against dir; an
+// absolute path is rebased onto dir (so a caller that normalizes references to absolute paths,
+// such as github.com/go-openapi/spec, still resolves correctly). Any path that would escape dir
+// — through ".." traversal, an absolute path pointing outside dir, or a symlink pointing outside
+// dir — is rejected. This is built on [os.Root] and is therefore resistant to the symlink
+// escapes that a plain [os.DirFS] does not prevent.
 //
 // WithRoot is the recommended option when loading specs from a location derived from
 // untrusted input. It applies to local loading only and has no effect on remote

--- a/loading/withroot_test.go
+++ b/loading/withroot_test.go
@@ -7,6 +7,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"testing/fstest"
 
@@ -48,6 +49,29 @@ func TestWithRoot(t *testing.T) {
 
 		t.Run("nested path", func(t *testing.T) {
 			b, err := LoadFromFileOrHTTP("sub/api.yaml", WithRoot(root))
+			require.NoError(t, err)
+			assert.EqualT(t, nested, string(b))
+		})
+	})
+
+	t.Run("should load absolute paths confined to the root", func(t *testing.T) {
+		// Callers such as go-openapi/spec normalize $ref targets to absolute paths before
+		// loading. These must resolve when they point within the root (they are rebased onto it),
+		// not be rejected merely for being absolute.
+		abs := filepath.Join(root, "api.yaml")
+		for _, pth := range []string{
+			abs,                               // absolute path within the root
+			"file://" + filepath.ToSlash(abs), // absolute path within the root, via a file:// URI
+		} {
+			t.Run(pth, func(t *testing.T) {
+				b, err := LoadFromFileOrHTTP(pth, WithRoot(root))
+				require.NoError(t, err)
+				assert.EqualT(t, inside, string(b))
+			})
+		}
+
+		t.Run("nested absolute path", func(t *testing.T) {
+			b, err := LoadFromFileOrHTTP(filepath.Join(root, "sub", "api.yaml"), WithRoot(root))
 			require.NoError(t, err)
 			assert.EqualT(t, nested, string(b))
 		})
@@ -110,5 +134,31 @@ func TestWithRoot(t *testing.T) {
 		b, err := LoadFromFileOrHTTP(filepath.Join(parent, "secret.txt"))
 		require.NoError(t, err)
 		assert.EqualT(t, secret, string(b))
+	})
+}
+
+func TestRootRelative(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "root")
+
+	t.Run("relative names are returned unchanged", func(t *testing.T) {
+		// os.Root confines relative names directly, so they are passed through verbatim.
+		for _, name := range []string{"api.yaml", "sub/api.yaml", "sub/../api.yaml", "../escape.yaml"} {
+			got, err := rootRelative(root, name)
+			require.NoError(t, err)
+			assert.EqualT(t, name, got)
+		}
+	})
+
+	t.Run("absolute in-root names are rebased onto the root", func(t *testing.T) {
+		got, err := rootRelative(root, filepath.Join(root, "sub", "api.yaml"))
+		require.NoError(t, err)
+		assert.EqualT(t, filepath.Join("sub", "api.yaml"), got)
+	})
+
+	t.Run("absolute escaping names yield a traversal path (rejected later by os.Root)", func(t *testing.T) {
+		got, err := rootRelative(root, filepath.Join(filepath.Dir(root), "secret.txt"))
+		require.NoError(t, err)
+		assert.TrueT(t, strings.HasPrefix(got, ".."+string(filepath.Separator)),
+			"expected a traversal path, got %q", got)
 	})
 }

--- a/loading/withroot_windows_test.go
+++ b/loading/withroot_windows_test.go
@@ -1,0 +1,20 @@
+// SPDX-FileCopyrightText: Copyright 2015-2025 go-swagger maintainers
+// SPDX-License-Identifier: Apache-2.0
+
+//go:build windows
+
+package loading
+
+import (
+	"testing"
+
+	"github.com/go-openapi/testify/v2/require"
+)
+
+func TestRootRelativeVolumeMismatch(t *testing.T) {
+	// A path on a different volume cannot be expressed relative to the root. filepath.Rel
+	// returns an error, which rootRelative must propagate so the read is rejected rather than
+	// silently escaping the root.
+	_, err := rootRelative(`C:\root`, `D:\secret.txt`)
+	require.Error(t, err)
+}


### PR DESCRIPTION
os.Root only accepts paths relative to its root and rejects any absolute path, even one that points inside the root. But callers that normalize references to absolute paths before loading — notably github.com/go-openapi/spec, which resolves every $ref to an absolute path against the spec's base — then had every confined read rejected, making WithRoot unusable for its primary purpose: safely resolving references in an untrusted document.

Rebase an absolute requested path onto the root (via filepath.Rel) before handing it to os.Root:

  - a relative path is passed through unchanged (os.Root confines it, including ".." traversal and symlink escapes);
  - an absolute path inside the root is rebased to a root-relative path and read;
  - an absolute path outside the root yields a "../" prefix and is rejected by os.Root;
  - a path that cannot be made relative to the root (e.g. a different volume on Windows) makes filepath.Rel return an error, which is propagated as a rejection rather than allowed to escape.

Symlink-escape protection is preserved: the rebase is purely lexical; the actual open still goes through os.Root, which resolves every path component within the root. Default behavior (no WithRoot) is unchanged.

## Change type

Please select: 🆕 New feature or enhancement|🔧 Bug fix'|📃 Documentation update

## Short description
<!-- Please provide a short description of your change -->

## Fixes
<!-- 
Example:
* fixes #123

Avoid cross-repository fixes, e.g.
* fixes go-openapi/spec#123

Prefer instead:
* contributes go-openapi/spec#123

This means will be solved, but when releases and dependencies updates have been carried out
-->

## Full description
<!-- If needed, please add here more details about your implementation etc -->

<!-- Since this is a bug fix, try your best not to mix this change with extra features or potentially breaking changes -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!-- If you don't qualify for all of the below check list items, please mark your PR in a draft status, so it may be discussed or reviewed with lighter requirements. -->

* [ ] I have signed all my commits with my name and email (see [DCO](https://github.com/apps/dco). **This does not require a PGP-signed commit**
* [ ] I have rebased and squashed my work, so only one commit remains
* [ ] I have added tests to cover my changes.
* [ ] I have properly enriched go doc comments in code.
* [ ] I have properly documented any breaking change.
